### PR TITLE
[Fix] not IsActive or IsDeprecated returns unauthorized response

### DIFF
--- a/CDP4Authentication/AuthenticationPerson.cs
+++ b/CDP4Authentication/AuthenticationPerson.cs
@@ -1,6 +1,25 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="AuthenticationPerson.cs" company="RHEA System S.A.">
-//   Copyright (c) 2016 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft.
+//
+//    This file is part of CDP4 Web Services Community Edition. 
+//    The CDP4 Web Services Community Edition is the RHEA implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4 Web Services Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4 Web Services Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -52,6 +71,11 @@ namespace CDP4Authentication
         /// Gets or sets a value indicating whether is active.
         /// </summary>
         public bool IsActive { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether is deprecated.
+        /// </summary>
+        public bool IsDeprecated { get; set; }
 
         /// <summary>
         /// Gets or sets the salt.

--- a/CDP4Orm/Dao/Authentication/AuthenticationDao.cs
+++ b/CDP4Orm/Dao/Authentication/AuthenticationDao.cs
@@ -1,6 +1,25 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="AuthenticationDao.cs" company="RHEA System S.A.">
-//   Copyright (c) 2016 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft.
+//
+//    This file is part of CDP4 Web Services Community Edition. 
+//    The CDP4 Web Services Community Edition is the RHEA implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4 Web Services Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4 Web Services Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -74,37 +93,38 @@ namespace CDP4Orm.Dao.Authentication
         /// </returns>
         private AuthenticationPerson MapToDto(NpgsqlDataReader reader)
         {
-            string tempIsActive;
-            string tempPassword;
-            string tempSalt;
-            string tempShortName;
-            
             var valueDict = (Dictionary<string, string>)reader["ValueTypeSet"];
             var iid = Guid.Parse(reader["Iid"].ToString());
             var revisionNumber = int.Parse(valueDict["RevisionNumber"]);
-            
-            var dto = new AuthenticationPerson(iid, revisionNumber);
 
-            dto.Role = reader["Role"] is DBNull ? (Guid?)null : Guid.Parse(reader["Role"].ToString());
-            dto.DefaultDomain = reader["DefaultDomain"] is DBNull? (Guid?)null : Guid.Parse(reader["DefaultDomain"].ToString());
-            dto.Organization = reader["Organization"] is DBNull ? (Guid?)null : Guid.Parse(reader["Organization"].ToString());
+            var dto = new AuthenticationPerson(iid, revisionNumber) 
+                { 
+                    Role = reader["Role"] is DBNull ? (Guid?) null : Guid.Parse(reader["Role"].ToString()), 
+                    DefaultDomain = reader["DefaultDomain"] is DBNull ? (Guid?) null : Guid.Parse(reader["DefaultDomain"].ToString()), 
+                    Organization = reader["Organization"] is DBNull ? (Guid?) null : Guid.Parse(reader["Organization"].ToString())
+                };
 
-            if (valueDict.TryGetValue("IsActive", out tempIsActive))
+            if (valueDict.TryGetValue("IsActive", out var tempIsActive))
             {
                 dto.IsActive = bool.Parse(tempIsActive);
             }
 
-            if (valueDict.TryGetValue("Password", out tempPassword) && !string.IsNullOrEmpty(tempPassword))
+            if (valueDict.TryGetValue("IsDeprecated", out var tempIsDeprecated))
+            {
+                dto.IsDeprecated = bool.Parse(tempIsDeprecated);
+            }
+
+            if (valueDict.TryGetValue("Password", out var tempPassword) && !string.IsNullOrEmpty(tempPassword))
             {
                 dto.Password = tempPassword.UnEscape();
             }
 
-            if (valueDict.TryGetValue("Salt", out tempSalt))
+            if (valueDict.TryGetValue("Salt", out var tempSalt))
             {
                 dto.Salt = tempSalt.UnEscape();
             }
 
-            if (valueDict.TryGetValue("ShortName", out tempShortName))
+            if (valueDict.TryGetValue("ShortName", out var tempShortName))
             {
                 // map shortname to UserName
                 dto.UserName = tempShortName.UnEscape();

--- a/CDP4WebServices.API/Modules/10-25/ApiBase.cs
+++ b/CDP4WebServices.API/Modules/10-25/ApiBase.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ApiBase.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft.
 //
@@ -33,7 +33,6 @@ namespace CDP4WebServices.API.Modules
     using System.Net.Http;
     using System.Security.Cryptography;
     using System.Text;
-    using System.Threading.Tasks;
 
     using CDP4Common.DTO;
 
@@ -384,6 +383,12 @@ namespace CDP4WebServices.API.Modules
         {
             // wireup cdp authorization support
             this.CdpAuthorization();
+
+            if (!this.IsAuthorized())
+            {
+                return this.GetUnauthorizedResponse();
+            }
+
             var response = this.GetResponseData(routeParams);
 
             // Register the required CDP4 headers to every response send
@@ -415,6 +420,12 @@ namespace CDP4WebServices.API.Modules
         {
             // wireup cdp authorization support
             this.CdpAuthorization();
+
+            if (!this.IsAuthorized())
+            {
+                return this.GetUnauthorizedResponse();
+            }
+            
             var response = this.PostResponseData(routeParams);
 
             this.HeaderInfoProvider.RegisterResponseHeaders(response);
@@ -493,6 +504,26 @@ namespace CDP4WebServices.API.Modules
                     requestToken),
                 StatusCode = statusCode
             };
+        }
+
+        /// <summary>
+        /// Checks if the user is authorized to perform reads or writes to the data store
+        /// </summary>
+        /// <returns>True is the user is authorized, otherwise false.</returns>
+        protected bool IsAuthorized()
+        {
+            var credentials = this.RequestUtils.Context.AuthenticatedCredentials;
+
+            return credentials.Person.IsActive && !credentials.Person.IsDeprecated;
+        }
+
+        /// <summary>
+        /// Gets the default Unauthorized <see cref="Response"/>
+        /// </summary>
+        /// <returns>The <see cref="Response"/></returns>
+        protected Response GetUnauthorizedResponse()
+        {
+            return HttpStatusCode.Unauthorized;
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
When Person.IsActive is set to false and/or when Person.IsDeprecated is set to true, the WebService returns an "Unauthorized" (HTTP StatusCode 401) response.