### PR TITLE
[Improve] performance of the OperationProcessor by allowing it to read from the Cahce tables instead of VIEWs where appropriate

### DIFF
--- a/CDP4WebServices.API.Tests/ChangeLog/ChangeLogTestFixture.cs
+++ b/CDP4WebServices.API.Tests/ChangeLog/ChangeLogTestFixture.cs
@@ -163,7 +163,7 @@ namespace CDP4WebServices.API.Tests.Services
                 TransactionManager = this.transactionManager.Object,
                 DataModelUtils = this.dataModelUtils,
             };
-
+            
             this.operationProcessor.Setup(x => x.OperationOriginalThingCache).Returns(new List<Thing>());
 
             this.requirementsSpecification = new RequirementsSpecification(Guid.NewGuid(), 0);
@@ -564,7 +564,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsFalse(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Never);
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Never);
 
             var engineeringModelClasslessDto = new ClasslessDTO()
             {
@@ -583,7 +583,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Once);
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Once);
         }
 
         [Test]
@@ -608,7 +608,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
         }
 
         [Test]
@@ -633,7 +633,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsFalse(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(0));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(0));
 
             things = new Thing[] { this.iteration, this.requirementsSpecification, this.elementDefinition_1, this.engineeringModel };
             postOperation.Create.Add(this.elementDefinition_1);
@@ -653,7 +653,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(1, this.existingModelLogEntry.LogEntryChangelogItem.Count);
         }
@@ -689,9 +689,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries.AddRange(operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray());
@@ -702,7 +702,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(2, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -784,9 +784,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries.AddRange(operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray());
@@ -797,7 +797,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(1, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -868,9 +868,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries = operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray();
@@ -883,7 +883,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(1, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -949,9 +949,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries = operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray();
@@ -962,7 +962,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(1, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -1031,9 +1031,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries = operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray();
@@ -1044,7 +1044,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Once);
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Once);
 
             Assert.AreEqual(2, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -1125,9 +1125,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries = operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray();
@@ -1138,7 +1138,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Once);
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Once);
 
             Assert.AreEqual(1, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -1203,9 +1203,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries = operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray();
@@ -1216,7 +1216,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(1, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -1279,9 +1279,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries.AddRange(operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray());
@@ -1292,7 +1292,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(2, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -1387,9 +1387,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries.AddRange(operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray());
@@ -1400,7 +1400,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(1, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -1479,9 +1479,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries = operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray();
@@ -1492,7 +1492,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(1, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -1567,9 +1567,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries = operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray();
@@ -1580,7 +1580,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(1, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -1661,9 +1661,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries.AddRange(operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray());
@@ -1674,7 +1674,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(2, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -1765,9 +1765,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries.AddRange(operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray());
@@ -1778,7 +1778,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(1, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -1851,9 +1851,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries = operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray();
@@ -1864,7 +1864,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(1, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -1937,9 +1937,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, resolveFromCache, files)
                         =>
                     {
                         createdLogEntries.AddRange(operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray());
@@ -1950,7 +1950,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(2, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 
@@ -2051,9 +2051,9 @@ namespace CDP4WebServices.API.Tests.Services
 
             this.operationProcessor.Setup(
                     x =>
-                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null))
-                .Callback<CdpPostOperation, NpgsqlTransaction, string, Dictionary<string, Stream>>(
-                    (operation, transaction, partition, files)
+                        x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null))
+                .Callback<CdpPostOperation, NpgsqlTransaction, string, bool, Dictionary<string, Stream>>(
+                    (operation, transaction, partition, files, resolveFromCache)
                         =>
                     {
                         createdLogEntries = operation.Create.Where(x => x.ClassKind == ClassKind.LogEntryChangelogItem).Cast<LogEntryChangelogItem>().ToArray();
@@ -2064,7 +2064,7 @@ namespace CDP4WebServices.API.Tests.Services
             Assert.IsTrue(result);
 
             this.operationProcessor.Verify(
-                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), null), Times.Exactly(1));
+                x => x.Process(It.IsAny<CdpPostOperation>(), null, It.IsAny<string>(), It.IsAny<bool>(), null), Times.Exactly(1));
 
             Assert.AreEqual(1, this.existingModelLogEntry.LogEntryChangelogItem.Count);
 

--- a/CDP4WebServices.API.Tests/OperationProcessorTestFixture.cs
+++ b/CDP4WebServices.API.Tests/OperationProcessorTestFixture.cs
@@ -102,6 +102,7 @@ namespace CDP4WebServices.API.Tests
         private Mock<API.Services.IServiceProvider> serviceProvider;
         private Mock<IResolveService> resolveService;
         private Mock<IPermissionService> permissionService;
+        private Mock<ICdp4TransactionManager> Cdp4TransactionManager;
 
         private OperationProcessor operationProcessor;
 
@@ -110,6 +111,9 @@ namespace CDP4WebServices.API.Tests
         [SetUp]
         public void TestSetup()
         {
+            this.Cdp4TransactionManager = new Mock<ICdp4TransactionManager>();
+            this.Cdp4TransactionManager.Setup(x => x.IsCachedDtoReadEnabled(It.IsAny<NpgsqlTransaction>())).Returns(true);
+
             this.mockedMetaInfoProvider = new Mock<IMetaInfoProvider>();
             this.transactionManager = new Mock<ICdp4TransactionManager>();
             this.requestUtils.MetaInfoProvider = this.mockedMetaInfoProvider.Object;
@@ -117,7 +121,9 @@ namespace CDP4WebServices.API.Tests
             this.operationProcessor.RequestUtils = this.requestUtils;
             this.operationSideEffectProcessor.RequestUtils = this.requestUtils;
             this.operationProcessor.OperationSideEffectProcessor = this.operationSideEffectProcessor;
-            
+            this.operationProcessor.TransactionManager = this.Cdp4TransactionManager.Object;
+
+
             this.serviceProvider = new Mock<API.Services.IServiceProvider>();
             this.resolveService = new Mock<IResolveService>();
 
@@ -629,7 +635,7 @@ namespace CDP4WebServices.API.Tests
 
             this.serviceProvider.Setup(x => x.MapToReadService(ClassKind.EngineeringModelSetup.ToString())).Returns(modelSetupService.Object);
             // targetIteration
-            this.operationProcessor.Process(postOperation, null, $"Iteration_{targetIteration.Iid.ToString().Replace("-", "_")}", null);
+            this.operationProcessor.Process(postOperation, null, $"Iteration_{targetIteration.Iid.ToString().Replace("-", "_")}", It.IsAny<bool>(), null);
 
             Assert.AreEqual(2, edDao.WrittenThingCount);
             Assert.AreEqual(2, paramDao.WrittenThingCount);

--- a/CDP4WebServices.API/Modules/10-25/EngineeringModelApi.cs
+++ b/CDP4WebServices.API/Modules/10-25/EngineeringModelApi.cs
@@ -392,7 +392,7 @@ namespace CDP4WebServices.API.Modules
                 // retrieve the revision for this transaction (or get next revision if it does not exist)
                 var transactionRevision = this.RevisionService.GetRevisionForTransaction(transaction, partition);
 
-                this.OperationProcessor.Process(operationData, transaction, partition, fileDictionary);
+                this.OperationProcessor.Process(operationData, transaction, partition, true, fileDictionary);
 
                 var actor = this.PermissionService.Credentials.Person.Iid;
 

--- a/CDP4WebServices.API/Modules/10-25/SiteDirectoryApi.cs
+++ b/CDP4WebServices.API/Modules/10-25/SiteDirectoryApi.cs
@@ -307,7 +307,7 @@ namespace CDP4WebServices.API.Modules
                 // retrieve the revision for this transaction (or get next revision if it does not exist)
                 var transactionRevision = this.RevisionService.GetRevisionForTransaction(transaction, TopContainer);
 
-                this.OperationProcessor.Process(operationData, transaction, TopContainer);
+                this.OperationProcessor.Process(operationData, transaction, TopContainer, true);
 
                 // save revision-history
                 var actor = credentials.Person.Iid;

--- a/CDP4WebServices.API/Services/ChangeLog/ChangeLogService.cs
+++ b/CDP4WebServices.API/Services/ChangeLog/ChangeLogService.cs
@@ -306,7 +306,7 @@ namespace CDP4WebServices.API.Services.ChangeLog
                             operationData.Update.Add(modelLogEntryClasslessDTO);
                         }
 
-                        this.OperationProcessor.Process(operationData, transaction, partition);
+                        this.OperationProcessor.Process(operationData, transaction, partition, false);
 
                         result = true;
                     }

--- a/CDP4WebServices.API/Services/Operations/IOperationProcessor.cs
+++ b/CDP4WebServices.API/Services/Operations/IOperationProcessor.cs
@@ -29,8 +29,6 @@ namespace CDP4WebServices.API.Services.Operations
 
     using CDP4Common.DTO;
 
-    using CDP4Orm.Dao.Resolve;
-
     using Npgsql;
 
     /// <summary>
@@ -50,10 +48,13 @@ namespace CDP4WebServices.API.Services.Operations
         /// <param name="partition">
         /// The database partition (schema) where the requested resource will be stored.
         /// </param>
+        /// <param name="resolveFromCache">
+        /// A value indicating whether meta data shall be resolved from the CAHCE tables or from the VIEWs
+        /// </param>
         /// <param name="fileStore">
         /// The optional file binaries that were included in the request.
         /// </param>
-        void Process(CdpPostOperation operation, NpgsqlTransaction transaction, string partition, Dictionary<string, Stream> fileStore = null);
+        void Process(CdpPostOperation operation, NpgsqlTransaction transaction, string partition, bool resolveFromCache, Dictionary<string, Stream> fileStore = null);
 
         /// <summary>
         /// Gets the operation original <see cref="Thing"/> instance cache.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The `OperationProcessor` needs to get original data from the datastore when processing. This data was queried from the VIEW tables, in this PR it is been queried from the CACHE tables for improved performance. 

Since the ChangeLogService is using the OperationProcessor as well, there is an exception since the ChangeLogService operates on updated data that is not yet stored in the cache tables

<!-- Thanks for contributing to COMET Web Services! -->