### PR TITLE
[Refactor] use of reference data and how it is queried from the database using a new CachedReferenceDataService; fixes #234

### DIFF
--- a/CDP4WebServices.API.Tests/SideEffects/ActualFiniteStateListSideEffectTestFixture.cs
+++ b/CDP4WebServices.API.Tests/SideEffects/ActualFiniteStateListSideEffectTestFixture.cs
@@ -53,7 +53,6 @@ namespace CDP4WebServices.API.Tests.SideEffects
         private Mock<IParameterOverrideService> parameterOverrideService;
         private Mock<IParameterSubscriptionService> parameterSubscriptionService;
         private Mock<IIterationService> iterationService;
-        private Mock<ICompoundParameterTypeService> compoundParameterTypeService;
         private Mock<IDefaultValueArrayFactory> defaultValueArrayFactory;
         private StateDependentParameterUpdateService parameterUpdateService;
 
@@ -121,7 +120,6 @@ namespace CDP4WebServices.API.Tests.SideEffects
             this.parameterOverrideService = new Mock<IParameterOverrideService>();
             this.parameterSubscriptionService = new Mock<IParameterSubscriptionService>();
             this.iterationService = new Mock<IIterationService>();
-            this.compoundParameterTypeService = new Mock<ICompoundParameterTypeService>();
             this.defaultValueArrayFactory = new Mock<IDefaultValueArrayFactory>();
             this.parameterUpdateService = new StateDependentParameterUpdateService();
             this.finateTrategyLogicService = new Mock<IFiniteStateLogicService>();
@@ -134,7 +132,6 @@ namespace CDP4WebServices.API.Tests.SideEffects
             this.parameterUpdateService.ParameterSubscriptionService = this.parameterSubscriptionService.Object;
             this.parameterUpdateService.ParameterOverrideValueSetService = this.parameterOverrideValueSetService.Object;
             this.parameterUpdateService.ParameterSubscriptionValueSetService = this.parameterSubscriptionValueSetService.Object;
-            this.parameterUpdateService.CompoundParameterTypeService = this.compoundParameterTypeService.Object;
 
             this.iteration = new Iteration(Guid.NewGuid(), 1);
             this.option1 = new Option(Guid.NewGuid(), 1);
@@ -369,10 +366,6 @@ namespace CDP4WebServices.API.Tests.SideEffects
                     x.GetShallow(this.transaction, this.partition, this.parameterSubscription2.ValueSet,
                         this.securityContext.Object))
                 .Returns(new List<Thing> { this.psvs21, this.psvs22 });
-
-            this.compoundParameterTypeService.Setup(
-                x => x.GetShallow(this.transaction, this.partition, It.IsAny<IEnumerable<Guid>>(), this.securityContext.Object))
-                .Returns(new List<Thing>());
 
             this.parameterService.Setup(x => x.GetShallow(this.transaction, this.partition, null, this.securityContext.Object))
                 .Returns(new List<Thing> { this.parameter1, this.parameter2 });

--- a/CDP4WebServices.API.Tests/SideEffects/ParameterTypeComponentSideEffectTestFixture.cs
+++ b/CDP4WebServices.API.Tests/SideEffects/ParameterTypeComponentSideEffectTestFixture.cs
@@ -26,15 +26,20 @@ namespace CDP4WebServices.API.Tests.SideEffects
 {
     using System;
     using System.Collections.Generic;
+
     using CDP4Common;
     using CDP4Common.DTO;
     using CDP4Common.Types;
+
     using CDP4WebServices.API.Helpers;
     using CDP4WebServices.API.Services;
     using CDP4WebServices.API.Services.Authorization;
     using CDP4WebServices.API.Services.Operations.SideEffects;
+
     using Moq;
+
     using Npgsql;
+
     using NUnit.Framework;
 
     /// <summary>
@@ -58,6 +63,8 @@ namespace CDP4WebServices.API.Tests.SideEffects
         private Mock<IParameterTypeComponentService> parameterTypeComponentService;
 
         private Mock<IDefaultValueArrayFactory> defaultValueArrayFactory;
+
+        private Mock<ICachedReferenceDataService> cachedReferenceDataService;
 
         private ParameterTypeComponentSideEffect sideEffect;
 
@@ -92,8 +99,10 @@ namespace CDP4WebServices.API.Tests.SideEffects
         {
             this.npgsqlTransaction = null;
             this.securityContext = new Mock<ISecurityContext>();
+            this.cachedReferenceDataService = new Mock<ICachedReferenceDataService>();
             this.defaultValueArrayFactory = new Mock<IDefaultValueArrayFactory>();
-
+            this.defaultValueArrayFactory.SetupProperty(x => x.CachedReferenceDataService, this.cachedReferenceDataService.Object);
+            
             // There is a chain cptA -> ptcA -> cptB -> ptcB -> bptD
             this.booleanParameterTypeD = new BooleanParameterType { Iid = Guid.NewGuid() };
             this.booleanParameterTypeE = new BooleanParameterType { Iid = Guid.NewGuid() };
@@ -253,6 +262,7 @@ namespace CDP4WebServices.API.Tests.SideEffects
                                   };
 
             this.sideEffect.DefaultValueArrayFactory = this.defaultValueArrayFactory.Object;
+            this.sideEffect.CachedReferenceDataService = this.cachedReferenceDataService.Object;
         }
 
         [Test]
@@ -291,6 +301,8 @@ namespace CDP4WebServices.API.Tests.SideEffects
             this.sideEffect.AfterCreate(It.IsAny<ParameterTypeComponent>(), It.IsAny<Thing>(), It.IsAny<ParameterTypeComponent>(), It.IsAny<NpgsqlTransaction>(), It.IsAny<string>(), It.IsAny<ISecurityContext>());
 
             this.defaultValueArrayFactory.Verify(x => x.Reset(), Times.Once);
+
+            this.cachedReferenceDataService.Verify(x => x.Reset(), Times.Once);
         }
 
         [Test]
@@ -299,6 +311,8 @@ namespace CDP4WebServices.API.Tests.SideEffects
             this.sideEffect.AfterDelete(It.IsAny<ParameterTypeComponent>(), It.IsAny<Thing>(), It.IsAny<ParameterTypeComponent>(), It.IsAny<NpgsqlTransaction>(), It.IsAny<string>(), It.IsAny<ISecurityContext>());
 
             this.defaultValueArrayFactory.Verify(x => x.Reset(), Times.Once);
+
+            this.cachedReferenceDataService.Verify(x => x.Reset(), Times.Once);
         }
 
         [Test]
@@ -307,6 +321,8 @@ namespace CDP4WebServices.API.Tests.SideEffects
             this.sideEffect.AfterUpdate(It.IsAny<ParameterTypeComponent>(), It.IsAny<Thing>(), It.IsAny<ParameterTypeComponent>(), It.IsAny<NpgsqlTransaction>(), It.IsAny<string>(), It.IsAny<ISecurityContext>());
 
             this.defaultValueArrayFactory.Verify(x => x.Reset(), Times.Once);
+
+            this.cachedReferenceDataService.Verify(x => x.Reset(), Times.Once);
         }
     }
 }

--- a/CDP4WebServices.API.Tests/SideEffects/ParameterTypeSideEffectTestFixture.cs
+++ b/CDP4WebServices.API.Tests/SideEffects/ParameterTypeSideEffectTestFixture.cs
@@ -25,26 +25,37 @@
 namespace CDP4WebServices.API.Tests.SideEffects
 {
     using CDP4Common.DTO;
+
     using CDP4WebServices.API.Services;
     using CDP4WebServices.API.Services.Authorization;
     using CDP4WebServices.API.Services.Operations.SideEffects.Implementation;
+
     using Moq;
+
     using Npgsql;
+
     using NUnit.Framework;
 
     [TestFixture]
     public class ParameterTypeSideEffectTestFixture
     {
         private ParameterTypeSideEffect parameterTypeSideEffect;
+
+        private Mock<ICachedReferenceDataService> cachedReferenceDataService;
         private Mock<IDefaultValueArrayFactory> defaultValueArrayFactory;
 
         [SetUp]
         public void SetUp()
         {
+            this.cachedReferenceDataService = new Mock<ICachedReferenceDataService>();
+            
             this.defaultValueArrayFactory = new Mock<IDefaultValueArrayFactory>();
+            this.defaultValueArrayFactory.SetupProperty(x => x.CachedReferenceDataService, this.cachedReferenceDataService.Object);
+
             this.parameterTypeSideEffect = new ParameterTypeSideEffect();
 
-            this.parameterTypeSideEffect.DefaultValueArrayFactory = defaultValueArrayFactory.Object;
+            this.parameterTypeSideEffect.DefaultValueArrayFactory = this.defaultValueArrayFactory.Object;
+            this.parameterTypeSideEffect.CachedReferenceDataService = this.cachedReferenceDataService.Object;
         }
 
         [Test]
@@ -53,6 +64,8 @@ namespace CDP4WebServices.API.Tests.SideEffects
             this.parameterTypeSideEffect.AfterCreate(It.IsAny<ParameterType>(), It.IsAny<Thing>(), It.IsAny<ParameterType>(), It.IsAny<NpgsqlTransaction>(), It.IsAny<string>(), It.IsAny<ISecurityContext>());
 
             this.defaultValueArrayFactory.Verify(x => x.Reset(), Times.Once);
+
+            this.cachedReferenceDataService.Verify(x => x.Reset(), Times.Once);
         }
 
         [Test]
@@ -61,6 +74,8 @@ namespace CDP4WebServices.API.Tests.SideEffects
             this.parameterTypeSideEffect.AfterDelete(It.IsAny<ParameterType>(), It.IsAny<Thing>(), It.IsAny<ParameterType>(), It.IsAny<NpgsqlTransaction>(), It.IsAny<string>(), It.IsAny<ISecurityContext>());
 
             this.defaultValueArrayFactory.Verify(x => x.Reset(), Times.Once);
+
+            this.cachedReferenceDataService.Verify(x => x.Reset(), Times.Once);
         }
 
         [Test]
@@ -69,6 +84,8 @@ namespace CDP4WebServices.API.Tests.SideEffects
             this.parameterTypeSideEffect.AfterUpdate(It.IsAny<ParameterType>(), It.IsAny<Thing>(), It.IsAny<ParameterType>(), It.IsAny<NpgsqlTransaction>(), It.IsAny<string>(), It.IsAny<ISecurityContext>());
 
             this.defaultValueArrayFactory.Verify(x => x.Reset(), Times.Once);
+
+            this.cachedReferenceDataService.Verify(x => x.Reset(), Times.Once);
         }
     }
 }

--- a/CDP4WebServices.API.Tests/SideEffects/PossibleFiniteStateListSideEffectTestFixture.cs
+++ b/CDP4WebServices.API.Tests/SideEffects/PossibleFiniteStateListSideEffectTestFixture.cs
@@ -138,7 +138,6 @@ namespace CDP4WebServices.API.Tests.SideEffects
             this.parameterUpdateService.ParameterService = this.parameterService.Object;
             this.parameterUpdateService.ParameterOverrideService = this.parameterOverrideService.Object;
             this.parameterUpdateService.ParameterSubscriptionService = this.parameterSubscriptionService.Object;
-            this.parameterUpdateService.CompoundParameterTypeService = this.compoundParameterTypeService.Object;
 
             this.iteration = new Iteration(Guid.NewGuid(), 1);
             this.option1 = new Option(Guid.NewGuid(), 1);

--- a/CDP4WebServices.API.Tests/SideEffects/PossibleFiniteStateSideEffectTestFixture.cs
+++ b/CDP4WebServices.API.Tests/SideEffects/PossibleFiniteStateSideEffectTestFixture.cs
@@ -26,13 +26,18 @@ namespace CDP4WebServices.API.Tests.SideEffects
 {
     using System;
     using System.Collections.Generic;
+
     using CDP4Common.DTO;
     using CDP4Common.Types;
+
     using CDP4WebServices.API.Services;
     using CDP4WebServices.API.Services.Authorization;
     using CDP4WebServices.API.Services.Operations.SideEffects;
+
     using Moq;
+
     using Npgsql;
+
     using NUnit.Framework;
 
     [TestFixture]
@@ -53,7 +58,6 @@ namespace CDP4WebServices.API.Tests.SideEffects
         private Mock<IParameterOverrideService> parameterOverrideService;
         private Mock<IParameterSubscriptionService> parameterSubscriptionService;
         private Mock<IIterationService> iterationService;
-        private Mock<ICompoundParameterTypeService> compoundParameterTypeService;
         private FiniteStateLogicService finiteStateLogicService;
         private StateDependentParameterUpdateService parameterUpdateService;
 
@@ -122,7 +126,6 @@ namespace CDP4WebServices.API.Tests.SideEffects
             this.parameterSubscriptionValueSetService = new Mock<IParameterSubscriptionValueSetService>();
             this.iterationService = new Mock<IIterationService>();
             this.defaultValueArrayFactory = new Mock<IDefaultValueArrayFactory>();
-            this.compoundParameterTypeService = new Mock<ICompoundParameterTypeService>();
             this.parameterUpdateService = new StateDependentParameterUpdateService();
             this.finiteStateLogicService = new FiniteStateLogicService();
 
@@ -132,7 +135,6 @@ namespace CDP4WebServices.API.Tests.SideEffects
             this.parameterUpdateService.ParameterOverrideService = this.parameterOverrideService.Object;
             this.parameterUpdateService.ParameterSubscriptionService = this.parameterSubscriptionService.Object;
             this.parameterUpdateService.ParameterSubscriptionValueSetService = this.parameterSubscriptionValueSetService.Object;
-            this.parameterUpdateService.CompoundParameterTypeService = this.compoundParameterTypeService.Object;
 
             this.iteration = new Iteration(Guid.NewGuid(), 1);
             this.option1 = new Option(Guid.NewGuid(), 1);
@@ -376,11 +378,7 @@ namespace CDP4WebServices.API.Tests.SideEffects
                     x.GetShallow(this.transaction, this.partition, this.parameterSubscription2.ValueSet,
                         this.securityContext.Object))
                 .Returns(new List<Thing> {this.psvs21, this.psvs22});
-
-            this.compoundParameterTypeService.Setup(
-                x => x.GetShallow(this.transaction, this.partition, It.IsAny<IEnumerable<Guid>>(), this.securityContext.Object))
-                .Returns(new List<Thing>());
-
+            
             this.defaultValueArrayFactory.Setup(x => x.CreateDefaultValueArray(It.IsAny<Guid>())).Returns(new ValueArray<string>(new[] { "-" }));
             this.finiteStateLogicService.ActualFiniteStateListService = this.actualFiniteStateListService.Object;
             this.finiteStateLogicService.ActualFiniteStateService = this.actualFiniteStateService.Object;

--- a/CDP4WebServices.API/Modules/10-25/EngineeringModelApi.cs
+++ b/CDP4WebServices.API/Modules/10-25/EngineeringModelApi.cs
@@ -306,16 +306,14 @@ namespace CDP4WebServices.API.Modules
 
             try
             {
-                var logMessage = $"{requestToken} started";
-                Logger.Info(this.ConstructLog(logMessage));
+                Logger.Info(this.ConstructLog($"{requestToken} started"));
 
                 HttpRequestHelper.ValidateSupportedQueryParameter(this.Request, this.RequestUtils, SupportedPostQueryParameter);
                 
                 var contentTypeRegex = new Regex("^multipart/.*;\\s*boundary=(.*)$", RegexOptions.IgnoreCase);
                 var isMultiPart = contentTypeRegex.IsMatch(this.Request.Headers.ContentType);
 
-                logMessage = $"Request {requestToken} is mutlipart: {isMultiPart}";
-                Logger.Debug(this.ConstructLog(logMessage));
+                Logger.Debug(this.ConstructLog($"Request {requestToken} is mutlipart: {isMultiPart}"));
 
                 Stream bodyStream;
                 Dictionary<string, Stream> fileDictionary = null;
@@ -343,8 +341,7 @@ namespace CDP4WebServices.API.Modules
                     {
                         var hash = this.FileBinaryService.CalculateHashFromStream(uploadedFile.Value);
 
-                        logMessage = $"File with hash {hash} present in request: {requestToken}";
-                        Logger.Debug(this.ConstructLog(logMessage));
+                        Logger.Debug(this.ConstructLog($"File with hash {hash} present in request: {requestToken}"));
 
                         fileDictionary.Add(hash, uploadedFile.Value);
                     }

--- a/CDP4WebServices.API/Services/BusinessLogic/ICachedReferenceDataService.cs
+++ b/CDP4WebServices.API/Services/BusinessLogic/ICachedReferenceDataService.cs
@@ -1,0 +1,129 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ICachedReferenceDataService.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski
+//
+//    This file is part of COMET Web Services Community Edition. 
+//    The COMET Web Services Community Edition is the RHEA implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The COMET Web Services Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The COMET Web Services Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4WebServices.API.Services
+{
+    using System;
+    using System.Collections.Generic;
+    
+    using CDP4Common.DTO;
+
+    using CDP4WebServices.API.Services.Authorization;
+
+    using Npgsql;
+
+    /// <summary>
+    /// The purpose of the <see cref="ICachedReferenceDataService"/> is to provide a caching service for data that is reusable accross
+    /// various services during the course of one request
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="ICachedReferenceDataService"/> is non-thread safe and should only be used per HTTP reequest
+    /// </remarks>
+    public interface ICachedReferenceDataService : IBusinessLogicService
+    {
+        /// <summary>
+        /// Gets or sets the (injected) <see cref="IParameterTypeService"/> used to query the <see cref="ParameterType"/>s from the data-store
+        /// </summary>
+        public IParameterTypeService ParameterTypeService { get; set; }
+
+        /// <summary>
+        /// Gets or sets the (injected) <see cref="IParameterTypeComponentService"/> used to query the <see cref="ParameterTypeComponent"/>s from the data-store
+        /// </summary>
+        public IParameterTypeComponentService ParameterTypeComponentService { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IDependentParameterTypeAssignmentService" />
+        /// </summary>
+        public IDependentParameterTypeAssignmentService DependentParameterTypeAssignmentService { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IIndependentParameterTypeAssignmentService" />
+        /// </summary>
+        public IIndependentParameterTypeAssignmentService IndependentParameterTypeAssignmentService { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the (injected) <see cref="IMeasurementScaleService"/> used to query the <see cref="MeasurementScale"/>s from the data-store
+        /// </summary>
+        public IMeasurementScaleService MeasurementScaleService { get; set; }
+
+        /// <summary>
+        /// Gets or sets the (injected) <see cref="IMeasurementUnitService"/> used to query the <see cref="MeasurementUnit"/>s from the data-store
+        /// </summary>
+        public IMeasurementUnitService MeasurementUnitService { get; set; }
+
+        /// <summary>
+        /// Queries the <see cref="ParameterType"/>s from the data from the datasource or from the cached list
+        /// </summary>
+        /// <returns>
+        /// An <see cref="Dictionary{Guid, ParameterType}"/>
+        /// </returns>
+        public Dictionary<Guid, ParameterType> QueryParameterTypes(NpgsqlTransaction transaction, ISecurityContext securityContext);
+
+        /// <summary>
+        /// Queries the <see cref="ParameterTypeComponent"/>s from the data from the datasource or from the cached list
+        /// </summary>
+        /// <returns>
+        /// An <see cref="Dictionary{Guid, ParameterTypeComponent}"/>
+        /// </returns>
+        public Dictionary<Guid, ParameterTypeComponent> QueryParameterTypeComponents(NpgsqlTransaction transaction, ISecurityContext securityContext);
+
+        /// <summary>
+        /// Queries the <see cref="ParameterType"/>s from the data from the datasource or from the cached list
+        /// </summary>
+        /// <returns>
+        /// An <see cref="Dictionary{Guid, ParameterType}"/>
+        /// </returns>
+        public Dictionary<Guid, DependentParameterTypeAssignment> QueryDependentParameterTypeAssignments(NpgsqlTransaction transaction, ISecurityContext securityContext);
+
+        /// <summary>
+        /// Queries the <see cref="ParameterType"/>s from the data from the datasource or from the cached list
+        /// </summary>
+        /// <returns>
+        /// An <see cref="Dictionary{Guid, ParameterType}"/>
+        /// </returns>
+        public Dictionary<Guid, IndependentParameterTypeAssignment> QueryIndependentParameterTypeAssignments(NpgsqlTransaction transaction, ISecurityContext securityContext);
+
+        /// <summary>
+        /// Queries the <see cref="MeasurementScale"/>s from the data from the datasource or from the cached list
+        /// </summary>
+        /// <returns>
+        /// An <see cref="Dictionary{Guid, MeasurementScale}"/>
+        /// </returns>
+        public Dictionary<Guid, MeasurementScale> QueryMeasurementScales(NpgsqlTransaction transaction, ISecurityContext securityContext);
+
+        /// <summary>
+        /// Queries the <see cref="MeasurementUnit"/>s from the data from the datasource or from the cached list
+        /// </summary>
+        /// <returns>
+        /// An <see cref="Dictionary{Guid, MeasurementUnit}"/>
+        /// </returns>
+        public Dictionary<Guid, MeasurementUnit> QueryMeasurementUnits(NpgsqlTransaction transaction, ISecurityContext securityContext);
+
+        /// <summary>
+        /// Resets (clears) the cached data from the <see cref="ICachedDataService" />.
+        /// </summary>
+        public void Reset();
+    }
+}

--- a/CDP4WebServices.API/Services/BusinessLogic/IDefaultValueArrayFactory.cs
+++ b/CDP4WebServices.API/Services/BusinessLogic/IDefaultValueArrayFactory.cs
@@ -42,7 +42,7 @@ namespace CDP4WebServices.API.Services
         /// <summary>
         /// Gets or sets the (injected) <see cref="ICachedReferenceDataService"/>
         /// </summary>
-        public ICachedReferenceDataService CachedReferenceDataService { get; set; }
+        ICachedReferenceDataService CachedReferenceDataService { get; set; }
 
         /// <summary>
         /// Initializes the <see cref="DefaultValueArrayFactory"/>.

--- a/CDP4WebServices.API/Services/BusinessLogic/IDefaultValueArrayFactory.cs
+++ b/CDP4WebServices.API/Services/BusinessLogic/IDefaultValueArrayFactory.cs
@@ -27,6 +27,7 @@ namespace CDP4WebServices.API.Services
     using System;
 
     using CDP4Common.Types;
+
     using CDP4WebServices.API.Services.Authorization;
 
     using Npgsql;
@@ -39,14 +40,9 @@ namespace CDP4WebServices.API.Services
     public interface IDefaultValueArrayFactory : IBusinessLogicService
     {
         /// <summary>
-        /// Gets or sets the <see cref="IParameterTypeService"/>
+        /// Gets or sets the (injected) <see cref="ICachedReferenceDataService"/>
         /// </summary>
-        IParameterTypeService ParameterTypeService { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="IParameterTypeComponentService"/>
-        /// </summary>
-        IParameterTypeComponentService ParameterTypeComponentService { get; set; }
+        public ICachedReferenceDataService CachedReferenceDataService { get; set; }
 
         /// <summary>
         /// Initializes the <see cref="DefaultValueArrayFactory"/>.

--- a/CDP4WebServices.API/Services/BusinessLogic/Implementation/CachedReferenceDataService.cs
+++ b/CDP4WebServices.API/Services/BusinessLogic/Implementation/CachedReferenceDataService.cs
@@ -6,7 +6,6 @@
 //
 //    This file is part of COMET Web Services Community Edition. 
 //    The COMET Web Services Community Edition is the RHEA implementation of ECSS-E-TM-10-25 Annex A and Annex C.
-//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The COMET Web Services Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Affero General Public

--- a/CDP4WebServices.API/Services/BusinessLogic/Implementation/CachedReferenceDataService.cs
+++ b/CDP4WebServices.API/Services/BusinessLogic/Implementation/CachedReferenceDataService.cs
@@ -1,0 +1,316 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CachedReferenceDataService.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski
+//
+//    This file is part of COMET Web Services Community Edition. 
+//    The COMET Web Services Community Edition is the RHEA implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The COMET Web Services Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The COMET Web Services Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4WebServices.API.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    using CDP4WebServices.API.Services.Authorization;
+
+    using NLog;
+
+    using Npgsql;
+
+    /// <summary>
+    /// The purpose of the <see cref="CachedReferenceDataService"/> is to provide a caching service for data that is reusable accross
+    /// various services during the course of one request
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="CachedReferenceDataService"/> is non-thread safe and should only be used per HTTP reequest
+    /// </remarks>
+    public class CachedReferenceDataService : ICachedReferenceDataService
+    {
+        /// <summary>
+        /// A <see cref="NLog.Logger"/> instance
+        /// </summary>
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        /// <summary>
+        /// the (per request) cached <see cref="ParameterType"/>
+        /// </summary>
+        private Dictionary<Guid, ParameterType> parameterTypeCache;
+
+        /// <summary>
+        /// the (per request) cached <see cref="ParameterTypeComponent"/>
+        /// </summary>
+        private Dictionary<Guid, ParameterTypeComponent> parameterTypeComponentCache;
+
+        /// <summary>
+        /// the (per request) cached <see cref="ParameterTypeComponent"/>
+        /// </summary>
+        private Dictionary<Guid, DependentParameterTypeAssignment> dependentParameterTypeAssignment;
+
+        /// <summary>
+        /// the (per request) cached <see cref="ParameterTypeComponent"/>
+        /// </summary>
+        private Dictionary<Guid, IndependentParameterTypeAssignment> independentParameterTypeAssignment;
+
+        /// <summary>
+        /// the (per request) cached <see cref="MeasurementScale"/>
+        /// </summary>
+        private Dictionary<Guid, MeasurementScale> measurementScaleCache;
+
+        /// <summary>
+        /// the (per request) cached <see cref="MeasurementUnit"/>
+        /// </summary>
+        private Dictionary<Guid, MeasurementUnit> measurementUnitCache;
+        
+        /// <summary>
+        /// Gets or sets the (injected) <see cref="IParameterTypeService"/> used to query the <see cref="ParameterType"/>s from the data-store
+        /// </summary>
+        public IParameterTypeService ParameterTypeService { get; set; }
+
+        /// <summary>
+        /// Gets or sets the (injected) <see cref="IParameterTypeComponentService"/> used to query the <see cref="ParameterTypeComponent"/>s from the data-store
+        /// </summary>
+        public IParameterTypeComponentService ParameterTypeComponentService { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IDependentParameterTypeAssignmentService" />
+        /// </summary>
+        public IDependentParameterTypeAssignmentService DependentParameterTypeAssignmentService { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IIndependentParameterTypeAssignmentService" />
+        /// </summary>
+        public IIndependentParameterTypeAssignmentService IndependentParameterTypeAssignmentService { get; set; }
+
+        /// <summary>
+        /// Gets or sets the (injected) <see cref="IMeasurementScaleService"/> used to query the <see cref="MeasurementScale"/>s from the data-store
+        /// </summary>
+        public IMeasurementScaleService MeasurementScaleService { get; set; }
+
+        /// <summary>
+        /// Gets or sets the (injected) <see cref="IMeasurementUnitService"/> used to query the <see cref="MeasurementUnit"/>s from the data-store
+        /// </summary>
+        public IMeasurementUnitService MeasurementUnitService { get; set; }
+
+        /// <summary>
+        /// Queries the <see cref="ParameterType"/>s from the data from the datasource or from the cached list
+        /// </summary>
+        /// <returns>
+        /// An <see cref="IEnumerable{ParameterType}"/>
+        /// </returns>
+        public Dictionary<Guid, ParameterType> QueryParameterTypes(NpgsqlTransaction transaction, ISecurityContext securityContext)
+        {
+            if (this.parameterTypeCache == null || this.parameterTypeCache.Count == 0)
+            {
+                var sw = new Stopwatch();
+
+                Logger.Debug("Querying ParameterTypes");
+
+                this.parameterTypeCache = new Dictionary<Guid, ParameterType>();
+
+                var parameterTypes = this.ParameterTypeService
+                    .GetShallow(transaction, CDP4Orm.Dao.Utils.SiteDirectoryPartition, null, securityContext)
+                    .OfType<ParameterType>();
+                
+                foreach (var parameterType in parameterTypes)
+                {
+                    this.parameterTypeCache.Add(parameterType.Iid, parameterType);
+                }
+
+                Logger.Debug($"ParameterTypes Queried in {sw.ElapsedMilliseconds} [ms]");
+            }
+
+            return this.parameterTypeCache;
+        }
+
+        /// <summary>
+        /// Queries the <see cref="ParameterTypeComponent"/>s from the data from the datasource or from the cached list
+        /// </summary>
+        /// <returns>
+        /// An <see cref="Dictionary{Guid, ParameterTypeComponent}"/>
+        /// </returns>
+        public Dictionary<Guid, ParameterTypeComponent> QueryParameterTypeComponents(NpgsqlTransaction transaction, ISecurityContext securityContext)
+        {
+            if (this.parameterTypeComponentCache == null || this.parameterTypeComponentCache.Count == 0)
+            {
+                var sw = new Stopwatch();
+
+                Logger.Debug("Querying ParameterTypeComponents");
+
+                this.parameterTypeComponentCache = new Dictionary<Guid, ParameterTypeComponent>();
+
+                var parameterTypeComponents = this.ParameterTypeComponentService
+                    .GetShallow(transaction, CDP4Orm.Dao.Utils.SiteDirectoryPartition, null, securityContext)
+                    .OfType<ParameterTypeComponent>();
+
+                foreach (var parameterTypeComponent in parameterTypeComponents)
+                {
+                    this.parameterTypeComponentCache.Add(parameterTypeComponent.Iid, parameterTypeComponent);
+                }
+
+                Logger.Debug($"ParameterTypeComponents Queried in {sw.ElapsedMilliseconds} [ms]");
+            }
+
+            return this.parameterTypeComponentCache;
+        }
+
+        /// <summary>
+        /// Queries the <see cref="ParameterType"/>s from the data from the datasource or from the cached list
+        /// </summary>
+        /// <returns>
+        /// An <see cref="Dictionary{Guid, ParameterType}"/>
+        /// </returns>
+        public Dictionary<Guid, DependentParameterTypeAssignment> QueryDependentParameterTypeAssignments(NpgsqlTransaction transaction, ISecurityContext securityContext)
+        {
+            if (this.dependentParameterTypeAssignment == null || this.dependentParameterTypeAssignment.Count == 0)
+            {
+                var sw = new Stopwatch();
+
+                Logger.Debug("Querying DependentParameterTypeAssignments");
+
+                this.dependentParameterTypeAssignment = new Dictionary<Guid, DependentParameterTypeAssignment>();
+
+                var dependentParameterTypeAssignments = this.ParameterTypeComponentService
+                    .GetShallow(transaction, CDP4Orm.Dao.Utils.SiteDirectoryPartition, null, securityContext)
+                    .OfType<DependentParameterTypeAssignment>();
+
+                foreach (var dependentParameterTypeAssignment in dependentParameterTypeAssignments)
+                {
+                    this.dependentParameterTypeAssignment.Add(dependentParameterTypeAssignment.Iid, dependentParameterTypeAssignment);
+                }
+
+                Logger.Debug($"DependentParameterTypeAssignments Queried in {sw.ElapsedMilliseconds} [ms]");
+            }
+
+            return this.dependentParameterTypeAssignment;
+        }
+
+        /// <summary>
+        /// Queries the <see cref="ParameterType"/>s from the data from the datasource or from the cached list
+        /// </summary>
+        /// <returns>
+        /// An <see cref="Dictionary{Guid, ParameterType}"/>
+        /// </returns>
+        public Dictionary<Guid, IndependentParameterTypeAssignment> QueryIndependentParameterTypeAssignments(NpgsqlTransaction transaction, ISecurityContext securityContext)
+        {
+            if (this.independentParameterTypeAssignment == null || this.independentParameterTypeAssignment.Count == 0)
+            {
+                var sw = new Stopwatch();
+
+                Logger.Debug("Querying DependentParameterTypeAssignments");
+
+                this.independentParameterTypeAssignment = new Dictionary<Guid, IndependentParameterTypeAssignment>();
+
+                var independentParameterTypeAssignments = this.ParameterTypeComponentService
+                    .GetShallow(transaction, CDP4Orm.Dao.Utils.SiteDirectoryPartition, null, securityContext)
+                    .OfType<IndependentParameterTypeAssignment>();
+
+                foreach (var independentParameterTypeAssignment in independentParameterTypeAssignments)
+                {
+                    this.independentParameterTypeAssignment.Add(independentParameterTypeAssignment.Iid, independentParameterTypeAssignment);
+                }
+
+                Logger.Debug($"IndependentParameterTypeAssignment Queried in {sw.ElapsedMilliseconds} [ms]");
+            }
+
+            return this.independentParameterTypeAssignment;
+        }
+
+        /// <summary>
+        /// Queries the <see cref="MeasurementScale"/>s from the data from the datasource or from the cached list
+        /// </summary>
+        /// <returns>
+        /// An <see cref="Dictionary{Guid, MeasurementScale}"/>
+        /// </returns>
+        public Dictionary<Guid, MeasurementScale> QueryMeasurementScales(NpgsqlTransaction transaction, ISecurityContext securityContext)
+        {
+            if (this.measurementScaleCache == null || this.measurementScaleCache.Count == 0)
+            {
+                var sw = new Stopwatch();
+
+                Logger.Debug("Querying MeasurementScales");
+
+                this.measurementScaleCache = new Dictionary<Guid, MeasurementScale>();
+
+                var measurementScales = this.MeasurementScaleService
+                    .GetShallow(transaction, CDP4Orm.Dao.Utils.SiteDirectoryPartition, null, securityContext)
+                    .OfType<MeasurementScale>();
+
+                foreach (var measurementScale in measurementScales)
+                {
+                    this.measurementScaleCache.Add(measurementScale.Iid, measurementScale);
+                }
+
+                Logger.Debug($"MeasurementScales Queried in {sw.ElapsedMilliseconds} [ms]");
+            }
+
+            return this.measurementScaleCache;
+        }
+
+        /// <summary>
+        /// Queries the <see cref="MeasurementUnit"/>s from the data from the datasource or from the cached list
+        /// </summary>
+        /// <returns>
+        /// An <see cref="Dictionary{Guid, MeasurementUnit}"/>
+        /// </returns>
+        public Dictionary<Guid, MeasurementUnit> QueryMeasurementUnits(NpgsqlTransaction transaction, ISecurityContext securityContext)
+        {
+            if (this.measurementUnitCache == null || this.measurementUnitCache.Count == 0)
+            {
+                var sw = new Stopwatch();
+
+                Logger.Debug("Querying MeasurementUnits");
+
+                this.measurementUnitCache = new Dictionary<Guid, MeasurementUnit>();
+
+                var measurementUnits = this.MeasurementUnitService
+                    .GetShallow(transaction, CDP4Orm.Dao.Utils.SiteDirectoryPartition, null, securityContext)
+                    .OfType<MeasurementUnit>();
+
+                foreach (var measurementUnit in measurementUnits)
+                {
+                    this.measurementUnitCache.Add(measurementUnit.Iid, measurementUnit);
+                }
+
+                Logger.Debug($"MeasurementUnits Queried in {sw.ElapsedMilliseconds} [ms]");
+            }
+
+            return this.measurementUnitCache;
+        }
+
+        /// <summary>
+        /// Resets (clears) the cached data from the <see cref="ICachedDataService" />.
+        /// </summary>
+        public void Reset()
+        {
+            this.parameterTypeCache?.Clear();
+            this.parameterTypeComponentCache?.Clear();
+            this.dependentParameterTypeAssignment?.Clear();
+            this.independentParameterTypeAssignment?.Clear();
+            this.measurementScaleCache?.Clear();
+            this.measurementUnitCache?.Clear();
+
+            Logger.Debug($"Cache Reset");
+        }
+    }
+}

--- a/CDP4WebServices.API/Services/BusinessLogic/Implementation/DefaultValueArrayFactory.cs
+++ b/CDP4WebServices.API/Services/BusinessLogic/Implementation/DefaultValueArrayFactory.cs
@@ -27,7 +27,6 @@ namespace CDP4WebServices.API.Services
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Linq;
 
     using CDP4Common.DTO;
     using CDP4Common.Types;
@@ -60,7 +59,7 @@ namespace CDP4WebServices.API.Services
         /// a cache of <see cref="ParameterType" />s that is populated in the context of the current
         /// <see cref="DefaultValueArrayFactory" />
         /// </summary>
-        private readonly Dictionary<Guid, ParameterType> parameterTypeCache = new Dictionary<Guid, ParameterType>();
+        private Dictionary<Guid, ParameterType> parameterTypeCache = new Dictionary<Guid, ParameterType>();
 
         /// <summary>
         /// a cache of <see cref="IParameterTypeAssignment" />s that is populated in the context of the current
@@ -72,7 +71,7 @@ namespace CDP4WebServices.API.Services
         /// a cache of <see cref="ParameterTypeComponent" />s that is populated in the context of the current
         /// <see cref="DefaultValueArrayFactory" />
         /// </summary>
-        private readonly Dictionary<Guid, ParameterTypeComponent> parameterTypeComponentCache = new Dictionary<Guid, ParameterTypeComponent>();
+        private Dictionary<Guid, ParameterTypeComponent> parameterTypeComponentCache = new Dictionary<Guid, ParameterTypeComponent>();
 
         /// <summary>
         /// a cache of the <see cref="ParameterType" />s and their number-of-values in the context of the current
@@ -81,29 +80,9 @@ namespace CDP4WebServices.API.Services
         private readonly Dictionary<ParameterType, int> parameterTypeNumberOfValuesMap = new Dictionary<ParameterType, int>();
 
         /// <summary>
-        /// Assertion that determines whether the <see cref="DefaultValueArrayFactory" /> is loaded.
+        /// Gets or sets the (injected) <see cref="ICachedReferenceDataService"/>
         /// </summary>
-        public bool IsLoaded { get; private set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="IParameterTypeService" />
-        /// </summary>
-        public IParameterTypeService ParameterTypeService { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="IIndependentParameterTypeAssignmentService" />
-        /// </summary>
-        public IIndependentParameterTypeAssignmentService IndependentParameterTypeAssignmentService { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="IDependentParameterTypeAssignmentService" />
-        /// </summary>
-        public IDependentParameterTypeAssignmentService DependentParameterTypeAssignmentService { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="IParameterTypeComponentService" />
-        /// </summary>
-        public IParameterTypeComponentService ParameterTypeComponentService { get; set; }
+        public ICachedReferenceDataService CachedReferenceDataService { get; set; }
 
         /// <summary>
         /// Load required data from the database, i.e. <see cref="ParameterType" /> and <see cref="ParameterTypeComponent" />
@@ -116,83 +95,33 @@ namespace CDP4WebServices.API.Services
         /// </param>
         public void Load(NpgsqlTransaction transaction, ISecurityContext securityContext)
         {
-            if (this.IsLoaded)
-            {
-                Logger.Trace("The DefaultValueArrayFactory has already been loaded, no need to hit the database again");
-                return;
-            }
-
-            Logger.Trace("Loading ParameterTypes and ParameterTypeComponents");
+            Logger.Trace("Loading reference data");
 
             var sw = Stopwatch.StartNew();
 
-            var parameterTypes = this.ParameterTypeService.GetShallow(
-                transaction,
-                CDP4Orm.Dao.Utils.SiteDirectoryPartition,
-                null,
-                securityContext).Cast<ParameterType>();
+            this.parameterTypeCache = this.CachedReferenceDataService.QueryParameterTypes(transaction, securityContext);
+            this.parameterTypeComponentCache = this.CachedReferenceDataService.QueryParameterTypeComponents(transaction, securityContext);
 
-            Logger.Trace("ParameterTypes loaded in {0} [ms]", sw.ElapsedMilliseconds);
+            var dependentParameterTypeAssignments = this.CachedReferenceDataService.QueryDependentParameterTypeAssignments(transaction, securityContext);
 
-            sw.Restart();
-
-            var parameterTypeComponents = this.ParameterTypeComponentService.GetShallow(
-                transaction,
-                CDP4Orm.Dao.Utils.SiteDirectoryPartition,
-                null,
-                securityContext).Cast<ParameterTypeComponent>();
-
-            Logger.Trace("ParameterTypeComponents loaded in {0} [ms]", sw.ElapsedMilliseconds);
-
-            sw.Restart();
-
-            var independentParameterTypeAssignments = this.IndependentParameterTypeAssignmentService.GetShallow(
-                transaction,
-                CDP4Orm.Dao.Utils.SiteDirectoryPartition,
-                null,
-                securityContext).Cast<IndependentParameterTypeAssignment>();
-
-            var dependentParameterTypeAssignments = this.DependentParameterTypeAssignmentService.GetShallow(
-                transaction,
-                CDP4Orm.Dao.Utils.SiteDirectoryPartition,
-                null,
-                securityContext).Cast<DependentParameterTypeAssignment>();
-
-            Logger.Trace("ParameterTypeAssignments loaded in {0} [ms]", sw.ElapsedMilliseconds);
-
-            sw.Restart();
-
-            Logger.Trace("Initializing ParameterType cache");
-
-            sw.Restart();
-
-            foreach (var parameterType in parameterTypes)
+            foreach (var kvp in dependentParameterTypeAssignments)
             {
-                this.parameterTypeCache.Add(parameterType.Iid, parameterType);
+                this.parameterTypeAssignmentCache.Add(kvp.Key, kvp.Value);
             }
 
-            Logger.Trace("Initializing ParameterTypeComponent cache");
+            var independentParameterTypeAssignments = this.CachedReferenceDataService.QueryIndependentParameterTypeAssignments(transaction, securityContext);
 
-            foreach (var parameterTypeComponent in parameterTypeComponents)
+            foreach (var kvp in independentParameterTypeAssignments)
             {
-                this.parameterTypeComponentCache.Add(parameterTypeComponent.Iid, parameterTypeComponent);
+                this.parameterTypeAssignmentCache.Add(kvp.Key, kvp.Value);
             }
-
-            Logger.Trace("Initializing ParameterTypeAssignments cache");
-
-            foreach (var parameterTypeAssignment in independentParameterTypeAssignments)
-            {
-                this.parameterTypeAssignmentCache.Add(parameterTypeAssignment.Iid, parameterTypeAssignment);
-            }
-
-            foreach (var parameterTypeAssignment in dependentParameterTypeAssignments)
-            {
-                this.parameterTypeAssignmentCache.Add(parameterTypeAssignment.Iid, parameterTypeAssignment);
-            }
-
-            this.IsLoaded = true;
-
-            Logger.Trace("Cache initialized with {0} ParameterTypes and {1} ParameterTypeComponents in {2}", this.parameterTypeCache.Count, this.parameterTypeComponentCache.Count, sw.ElapsedMilliseconds);
+            
+            Logger.Trace("Cache initialized with {0} ParameterTypes, {1} DependentParameterTypeAssignments, {2} IndependentParameterTypeAssignments and {3} ParameterTypeComponents in {4}", 
+                this.parameterTypeCache.Count, 
+                dependentParameterTypeAssignments.Count,
+                independentParameterTypeAssignments.Count,
+                this.parameterTypeComponentCache.Count,
+                sw.ElapsedMilliseconds);
         }
 
         /// <summary>
@@ -209,7 +138,6 @@ namespace CDP4WebServices.API.Services
             this.parameterTypeAssignmentCache.Clear();
             this.parameterTypeComponentCache.Clear();
             this.parameterTypeNumberOfValuesMap.Clear();
-            this.IsLoaded = false;
         }
 
         /// <summary>

--- a/CDP4WebServices.API/Services/BusinessLogic/Implementation/StateDependentParameterUpdateService.cs
+++ b/CDP4WebServices.API/Services/BusinessLogic/Implementation/StateDependentParameterUpdateService.cs
@@ -80,12 +80,7 @@ namespace CDP4WebServices.API.Services
         /// Gets or sets the <see cref="IParameterSubscriptionValueSetService"/>
         /// </summary>
         public IParameterSubscriptionValueSetService ParameterSubscriptionValueSetService { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="ICompoundParameterTypeService"/>
-        /// </summary>
-        public ICompoundParameterTypeService CompoundParameterTypeService { get; set; }
-
+        
         /// <summary>
         /// Gets or sets the <see cref="IParameterValueSetFactory"/>
         /// </summary>
@@ -147,7 +142,6 @@ namespace CDP4WebServices.API.Services
             }
         }
 
-        #region Update Parameters
         /// <summary>
         /// Update a <see cref="Parameter"/> with new <see cref="ParameterValueSet"/>
         /// </summary>
@@ -252,9 +246,7 @@ namespace CDP4WebServices.API.Services
             this.ParameterValueSetService.CreateConcept(transaction, partition, valueSet, parameter);
             return valueSet;
         }
-        #endregion
 
-        #region ParameterOVerride
         /// <summary>
         /// Update a <see cref="ParameterOverride"/> with new <see cref="CDP4Common.DTO.ParameterOverrideValueSet"/>
         /// </summary>
@@ -314,9 +306,7 @@ namespace CDP4WebServices.API.Services
             this.ParameterOverrideValueSetService.CreateConcept(transaction, partition, newValueSet, container);
             return newValueSet;
         }
-        #endregion
 
-        #region Parameter Subscription
         /// <summary>
         /// Update a <see cref="ParameterSubscription"/> with new <see cref="CDP4Common.DTO.ParameterSubscriptionValueSet"/>
         /// </summary>
@@ -364,6 +354,5 @@ namespace CDP4WebServices.API.Services
 
             this.ParameterSubscriptionValueSetService.CreateConcept(transaction, partition, newValueSet, container);
         }
-        #endregion
     }
 }

--- a/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/DependentParameterTypeAssignmentSideEffect.cs
+++ b/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/DependentParameterTypeAssignmentSideEffect.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ParameterTypeSideEffect.cs" company="RHEA System S.A.">
+// <copyright file="DependentParameterTypeAssignmentSideEffect.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2021 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski
@@ -22,18 +22,18 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace CDP4WebServices.API.Services.Operations.SideEffects.Implementation
+namespace CDP4WebServices.API.Services.Operations.SideEffects
 {
     using CDP4Common.DTO;
-
+    
     using CDP4WebServices.API.Services.Authorization;
 
     using Npgsql;
 
     /// <summary>
-    /// The purpose of the <see cref="ParameterTypeSideEffect"/> class is to execute additional logic before and after a specific operation is performed.
+    /// The purpose of the <see cref="DependentParameterTypeAssignmentSideEffect"/> class is to execute additional logic before and after a specific operation is performed.
     /// </summary>
-    public sealed class ParameterTypeSideEffect : OperationSideEffect<ParameterType>
+    public class DependentParameterTypeAssignmentSideEffect : OperationSideEffect<DependentParameterTypeAssignment>
     {
         /// <summary>
         /// Gets or sets the <see cref="IDefaultValueArrayFactory"/>
@@ -66,8 +66,7 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects.Implementation
         /// <param name="securityContext">
         /// The security Context used for permission checking.
         /// </param>
-        public override void AfterCreate(ParameterType thing, Thing container, ParameterType originalThing,
-            NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
+        public override void AfterCreate(DependentParameterTypeAssignment thing, Thing container, DependentParameterTypeAssignment originalThing, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
         {
             // reset the IDefaultValueArrayFactory, this may be used during the same transaction, any update to the ParameterTypeComponents needs to reset the IDefaultValueArrayFactory cache
             this.DefaultValueArrayFactory.Reset();
@@ -97,8 +96,7 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects.Implementation
         /// <param name="securityContext">
         /// The security Context used for permission checking.
         /// </param>
-        public override void AfterDelete(ParameterType thing, Thing container, ParameterType originalThing,
-            NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
+        public override void AfterDelete(DependentParameterTypeAssignment thing, Thing container, DependentParameterTypeAssignment originalThing, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
         {
             // reset the IDefaultValueArrayFactory, this may be used during the same transaction, any update to the ParameterTypeComponents needs to reset the IDefaultValueArrayFactory cache
             this.DefaultValueArrayFactory.Reset();
@@ -128,8 +126,7 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects.Implementation
         /// <param name="securityContext">
         /// The security Context used for permission checking.
         /// </param>
-        public override void AfterUpdate(ParameterType thing, Thing container, ParameterType originalThing, NpgsqlTransaction transaction,
-            string partition, ISecurityContext securityContext)
+        public override void AfterUpdate(DependentParameterTypeAssignment thing, Thing container, DependentParameterTypeAssignment originalThing, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
         {
             // reset the IDefaultValueArrayFactory, this may be used during the same transaction, any update to the ParameterTypeComponents needs to reset the IDefaultValueArrayFactory cache
             this.DefaultValueArrayFactory.Reset();

--- a/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IndependentParameterTypeAssignmentSideEffect.cs
+++ b/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IndependentParameterTypeAssignmentSideEffect.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ParameterTypeSideEffect.cs" company="RHEA System S.A.">
+// <copyright file="IndependentParameterTypeAssignmentSideEffect.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2021 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski
@@ -22,7 +22,8 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace CDP4WebServices.API.Services.Operations.SideEffects.Implementation
+
+namespace CDP4WebServices.API.Services.Operations.SideEffects
 {
     using CDP4Common.DTO;
 
@@ -31,9 +32,9 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects.Implementation
     using Npgsql;
 
     /// <summary>
-    /// The purpose of the <see cref="ParameterTypeSideEffect"/> class is to execute additional logic before and after a specific operation is performed.
+    /// The purpose of the <see cref="DependentParameterTypeAssignmentSideEffect"/> class is to execute additional logic before and after a specific operation is performed.
     /// </summary>
-    public sealed class ParameterTypeSideEffect : OperationSideEffect<ParameterType>
+    public class IndependentParameterTypeAssignmentSideEffect : OperationSideEffect<IndependentParameterTypeAssignment>
     {
         /// <summary>
         /// Gets or sets the <see cref="IDefaultValueArrayFactory"/>
@@ -66,8 +67,7 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects.Implementation
         /// <param name="securityContext">
         /// The security Context used for permission checking.
         /// </param>
-        public override void AfterCreate(ParameterType thing, Thing container, ParameterType originalThing,
-            NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
+        public override void AfterCreate(IndependentParameterTypeAssignment thing, Thing container, IndependentParameterTypeAssignment originalThing, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
         {
             // reset the IDefaultValueArrayFactory, this may be used during the same transaction, any update to the ParameterTypeComponents needs to reset the IDefaultValueArrayFactory cache
             this.DefaultValueArrayFactory.Reset();
@@ -97,8 +97,7 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects.Implementation
         /// <param name="securityContext">
         /// The security Context used for permission checking.
         /// </param>
-        public override void AfterDelete(ParameterType thing, Thing container, ParameterType originalThing,
-            NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
+        public override void AfterDelete(IndependentParameterTypeAssignment thing, Thing container, IndependentParameterTypeAssignment originalThing, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
         {
             // reset the IDefaultValueArrayFactory, this may be used during the same transaction, any update to the ParameterTypeComponents needs to reset the IDefaultValueArrayFactory cache
             this.DefaultValueArrayFactory.Reset();
@@ -128,8 +127,7 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects.Implementation
         /// <param name="securityContext">
         /// The security Context used for permission checking.
         /// </param>
-        public override void AfterUpdate(ParameterType thing, Thing container, ParameterType originalThing, NpgsqlTransaction transaction,
-            string partition, ISecurityContext securityContext)
+        public override void AfterUpdate(IndependentParameterTypeAssignment thing, Thing container, IndependentParameterTypeAssignment originalThing, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
         {
             // reset the IDefaultValueArrayFactory, this may be used during the same transaction, any update to the ParameterTypeComponents needs to reset the IDefaultValueArrayFactory cache
             this.DefaultValueArrayFactory.Reset();

--- a/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IndependentParameterTypeAssignmentSideEffect.cs
+++ b/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IndependentParameterTypeAssignmentSideEffect.cs
@@ -22,7 +22,6 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-
 namespace CDP4WebServices.API.Services.Operations.SideEffects
 {
     using CDP4Common.DTO;

--- a/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/ParameterTypeComponentSideEffect.cs
+++ b/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/ParameterTypeComponentSideEffect.cs
@@ -72,6 +72,11 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         public IDefaultValueArrayFactory DefaultValueArrayFactory { get; set; }
 
         /// <summary>
+        /// Gets or sets the (injected) <see cref="ICachedReferenceDataService"/>
+        /// </summary>
+        public ICachedReferenceDataService CachedReferenceDataService { get; set; }
+
+        /// <summary>
         /// Allows derived classes to override and execute additional logic after a successful create operation.
         /// </summary>
         /// <param name="thing">
@@ -97,6 +102,9 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         {
             // reset the IDefaultValueArrayFactory, this may be used during the same transaction, any update to the ParameterTypeComponents needs to reset the IDefaultValueArrayFactory cache
             this.DefaultValueArrayFactory.Reset();
+
+            // reset the ICachedReferenceDataService, this may be used during the same transaction, any update to the ParameterTypeComponents needs to reset the IDefaultValueArrayFactory cache
+            this.CachedReferenceDataService.Reset();
         }
 
         /// <summary>
@@ -125,6 +133,9 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         {
             // reset the IDefaultValueArrayFactory, this may be used during the same transaction, any update to the ParameterTypeComponents needs to reset the IDefaultValueArrayFactory cache
             this.DefaultValueArrayFactory.Reset();
+
+            // reset the ICachedReferenceDataService, this may be used during the same transaction, any update to the ParameterTypeComponents needs to reset the IDefaultValueArrayFactory cache
+            this.CachedReferenceDataService.Reset();
         }
 
         /// <summary>
@@ -153,6 +164,9 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         {
             // reset the IDefaultValueArrayFactory, this may be used during the same transaction, any update to the ParameterTypeComponents needs to reset the IDefaultValueArrayFactory cache
             this.DefaultValueArrayFactory.Reset();
+
+            // reset the ICachedReferenceDataService, this may be used during the same transaction, any update to the ParameterTypeComponents needs to reset the IDefaultValueArrayFactory cache
+            this.CachedReferenceDataService.Reset();
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
When a Parameter is created or updated reference data such as ParameterTypes and MeasurementScales are necessary to verify that the POST is correct and we do not end up with an incomplete dataset. Due to the fact that reference data and parameter data cannot be changed inside of one POST operation it is safe to query the reference data from the Cache tables of the database and store them in memory of the services to reuse for multiple operations. 

This is implemented in the `CachedReferenceDataService` and has led to a refactoring of the
  - ParameterSideEffect
  - DefaultValueArrayFactory

<!-- Thanks for contributing to COMET Web Services! -->