### PR TITLE
ParameterTypeAssignmentCache not being cleared would lead to duplicate keys exception

### DIFF
--- a/CDP4WebServices.API/Services/BusinessLogic/Implementation/DefaultValueArrayFactory.cs
+++ b/CDP4WebServices.API/Services/BusinessLogic/Implementation/DefaultValueArrayFactory.cs
@@ -102,6 +102,8 @@ namespace CDP4WebServices.API.Services
             this.parameterTypeCache = this.CachedReferenceDataService.QueryParameterTypes(transaction, securityContext);
             this.parameterTypeComponentCache = this.CachedReferenceDataService.QueryParameterTypeComponents(transaction, securityContext);
 
+            this.parameterTypeAssignmentCache.Clear();
+
             var dependentParameterTypeAssignments = this.CachedReferenceDataService.QueryDependentParameterTypeAssignments(transaction, securityContext);
 
             foreach (var kvp in dependentParameterTypeAssignments)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Bug found by OHB. When copying EDs and there is a SFPT in the RDL chain, an exception would get thrown on the server stopping the copy due to cache dictionary not being cleaned up.