### PR TITLE
Implement create engineering model setup on modify if participant; fixes #295

### DIFF
--- a/CometServer.Tests/Authorization/PermissionServiceTestFixture.cs
+++ b/CometServer.Tests/Authorization/PermissionServiceTestFixture.cs
@@ -159,6 +159,66 @@ namespace CometServer.Tests.Authorization
         }
 
         [Test]
+        public void VerifyCreateEngineeringModelSetup()
+        {
+            //-------------------------------------------------------------
+            // Setup
+            //-------------------------------------------------------------
+            this.accessRightKindService.Setup(
+                    x =>
+                        x.QueryPersonAccessRightKind(It.IsAny<Credentials>(), ClassKind.EngineeringModelSetup.ToString()))
+                .Returns(PersonAccessRightKind.MODIFY_IF_PARTICIPANT);
+
+            Assert.IsTrue(
+                this.permissionService.CanWrite(
+                    null,
+                    new EngineeringModelSetup(),
+                    ClassKind.EngineeringModelSetup.ToString(),
+                    SiteDirectoryPartition,
+                    ServiceBase.CreateOperation,
+                    new RequestSecurityContext()
+                ));
+
+            Assert.IsFalse(
+                this.permissionService.CanWrite(
+                    null,
+                    new EngineeringModelSetup(),
+                    ClassKind.EngineeringModelSetup.ToString(),
+                    SiteDirectoryPartition,
+                    ServiceBase.UpdateOperation,
+                    new RequestSecurityContext()
+                ));
+
+            //-------------------------------------------------------------
+            // Setup
+            //-------------------------------------------------------------
+            this.accessRightKindService.Setup(
+                    x =>
+                        x.QueryPersonAccessRightKind(It.IsAny<Credentials>(), ClassKind.EngineeringModelSetup.ToString()))
+                .Returns(PersonAccessRightKind.MODIFY);
+
+            Assert.IsTrue(
+                this.permissionService.CanWrite(
+                    null,
+                    new EngineeringModelSetup(),
+                    ClassKind.EngineeringModelSetup.ToString(),
+                    SiteDirectoryPartition,
+                    ServiceBase.CreateOperation,
+                    new RequestSecurityContext()
+                ));
+
+            Assert.IsTrue(
+                this.permissionService.CanWrite(
+                    null,
+                    new EngineeringModelSetup(),
+                    ClassKind.EngineeringModelSetup.ToString(),
+                    SiteDirectoryPartition,
+                    ServiceBase.UpdateOperation,
+                    new RequestSecurityContext()
+                ));
+        }
+
+        [Test]
         [TestCaseSource(nameof(TestCases))]
         public void VerifySameAsContainerPermissionAutorization(Thing containerThing, Thing thing, string partition)
         {

--- a/CometServer/Authorization/PermissionService.cs
+++ b/CometServer/Authorization/PermissionService.cs
@@ -333,7 +333,8 @@ namespace CometServer.Authorization
 
                     case PersonAccessRightKind.MODIFY_IF_PARTICIPANT:
                         {
-                            return this.IsEngineeringModelSetupModifyAllowed(thing, modifyOperation);
+                            return this.IsEngineeringModelSetupModifyAllowed(thing, modifyOperation) || 
+                                   this.IsCreateAllowedForOperationOnThing(thing, modifyOperation);
                         }
 
                     case PersonAccessRightKind.MODIFY_OWN_PERSON:
@@ -450,6 +451,17 @@ namespace CometServer.Authorization
                         return false;
                     }
             }
+        }
+
+        /// <summary>
+        /// Check if (overridden) Create operation is allowed for an EngineeringModelSetup, when the user has MODIFY_IF_PARTICIPANT access rights
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> to check</param>
+        /// <param name="modifyOperation">The kind of operation we are performing</param>
+        /// <returns>True if create is allowed, otherwise false</returns>
+        private bool IsCreateAllowedForOperationOnThing(Thing thing, string modifyOperation)
+        {
+            return modifyOperation == CreateOperation && thing is EngineeringModelSetup;
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Implement create EngineeringModelSetup when PersonAccessRight is set to MODIFY_IF_PARTICIPANT on EngineeringModelSetup