### PR TITLE
SQ Improvements

### DIFF
--- a/CDP4DatabaseAuthentication/Cdp4DatabaseAuthenticatorConnector.cs
+++ b/CDP4DatabaseAuthentication/Cdp4DatabaseAuthenticatorConnector.cs
@@ -87,7 +87,7 @@ namespace CDP4DatabaseAuthentication
         /// </returns>
         public override bool Authenticate(AuthenticationPerson person, string password)
         {
-            return this.ValidatePassword(password, person);
+            return ValidatePassword(password, person);
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace CDP4DatabaseAuthentication
         /// <returns>
         /// True if the passwords match.
         /// </returns>
-        private bool ValidatePassword(string password, AuthenticationPerson person)
+        private static bool ValidatePassword(string password, AuthenticationPerson person)
         {
             return EncryptionUtils.CompareSaltedStrings(password, person.Password, person.Salt);
         }

--- a/CDP4Orm/Dao/Authentication/AuthenticationPersonDao.cs
+++ b/CDP4Orm/Dao/Authentication/AuthenticationPersonDao.cs
@@ -93,7 +93,7 @@ namespace CDP4Orm.Dao.Authentication
 
             while (await reader.ReadAsync())
             {
-                var authenticationPerson = this.MapToDto(reader);
+                var authenticationPerson = MapToDto(reader);
                 result.Add(authenticationPerson);
             }
 
@@ -109,7 +109,7 @@ namespace CDP4Orm.Dao.Authentication
         /// <returns>
         /// A deserialized instance of <see cref="AuthenticationPerson"/>.
         /// </returns>
-        private AuthenticationPerson MapToDto(NpgsqlDataReader reader)
+        private static AuthenticationPerson MapToDto(NpgsqlDataReader reader)
         {
             var valueDict = (Dictionary<string, string>)reader["ValueTypeSet"];
             var iid = Guid.Parse(reader["Iid"].ToString());

--- a/CDP4Orm/Dao/BaseDao.cs
+++ b/CDP4Orm/Dao/BaseDao.cs
@@ -271,19 +271,17 @@ namespace CDP4Orm.Dao
         /// <param name="transaction">The current transaction</param>
         /// <param name="partition">The partition of the table to delete</param>
         /// <param name="table">The table to clear</param>
-        protected void DeleteAll(NpgsqlTransaction transaction, string partition, string table)
+        protected static void DeleteAll(NpgsqlTransaction transaction, string partition, string table)
         {
-            using (var command = new NpgsqlCommand())
-            {
-                var sqlBuilder = new System.Text.StringBuilder();
+            using var command = new NpgsqlCommand();
+            var sqlBuilder = new System.Text.StringBuilder();
 
-                sqlBuilder.AppendFormat("DELETE FROM \"{0}\".\"{1}\";", partition, table);
+            sqlBuilder.AppendFormat("DELETE FROM \"{0}\".\"{1}\";", partition, table);
 
-                command.CommandText = sqlBuilder.ToString();
-                command.Connection = transaction.Connection;
-                command.Transaction = transaction;
-                command.ExecuteNonQuery();
-            }
+            command.CommandText = sqlBuilder.ToString();
+            command.Connection = transaction.Connection;
+            command.Transaction = transaction;
+            command.ExecuteNonQuery();
         }
 
         /// <summary>
@@ -297,13 +295,11 @@ namespace CDP4Orm.Dao
             {
                 this.currentTransactionDataTimeTransaction = transaction;
 
-                using (var command = new NpgsqlCommand(
+                using var command = new NpgsqlCommand(
                     $"SELECT * FROM \"SiteDirectory\".\"get_transaction_time\"();",
                     transaction.Connection,
-                    transaction))
-                {
-                    this.currentTransactionDatetime = (DateTime)command.ExecuteScalar();
-                }
+                    transaction);
+                this.currentTransactionDatetime = (DateTime)command.ExecuteScalar();
             }
 
             return this.currentTransactionDatetime;

--- a/CDP4Orm/Dao/Cache/CacheDao.cs
+++ b/CDP4Orm/Dao/Cache/CacheDao.cs
@@ -84,7 +84,7 @@ namespace CDP4Orm.Dao.Cache
         /// <param name="thing">The revised <see cref="CDP4Common.DTO.Thing"/></param>
         public void Write(NpgsqlTransaction transaction, string partition, Thing thing)
         {
-            var table = this.GetThingCacheTableName(thing);
+            var table = GetThingCacheTableName(thing);
 
             var columns = string.Format("(\"{0}\", \"{1}\", \"{2}\")", IidKey, RevisionColumnName, JsonColumnName);
             var values = "(:iid, :revisionnumber, :jsonb)";
@@ -106,7 +106,7 @@ namespace CDP4Orm.Dao.Cache
         /// </summary>
         /// <param name="thing">The <see cref="Thing"/></param>
         /// <returns>The name of the revision table</returns>
-        private string GetThingCacheTableName(Thing thing)
+        private static string GetThingCacheTableName(Thing thing)
         {
             return thing.ClassKind + CacheTableSuffix;
         }

--- a/CDP4Orm/Dao/Resolve/ContainerDao.cs
+++ b/CDP4Orm/Dao/Resolve/ContainerDao.cs
@@ -141,7 +141,7 @@ namespace CDP4Orm.Dao.Resolve
                 {
                     while (reader.Read())
                     {
-                        yield return this.MapToSiteDirectoryContainmentInfo(reader, connectedPartition);
+                        yield return MapToSiteDirectoryContainmentInfo(reader, connectedPartition);
                     }
                 }
             }
@@ -159,7 +159,7 @@ namespace CDP4Orm.Dao.Resolve
         /// <returns>
         /// A deserialized instance of <see cref="ContainerInfo"/>.
         /// </returns>
-        private Tuple<Guid, ContainerInfo> MapToSiteDirectoryContainmentInfo(NpgsqlDataReader reader, string connectedPartition)
+        private static Tuple<Guid, ContainerInfo> MapToSiteDirectoryContainmentInfo(NpgsqlDataReader reader, string connectedPartition)
         {
             var containedIid = (Guid)reader[ContainedIidKey];
 
@@ -240,7 +240,7 @@ namespace CDP4Orm.Dao.Resolve
                 {
                     while (reader.Read())
                     {
-                        yield return this.MapToEngineeringModelContainmentInfo(reader, connectedPartition, otherPartition);
+                        yield return MapToEngineeringModelContainmentInfo(reader, connectedPartition, otherPartition);
                     }
                 }
             }
@@ -261,7 +261,7 @@ namespace CDP4Orm.Dao.Resolve
         /// <returns>
         /// A deserialized instance of <see cref="ContainerInfo"/>.
         /// </returns>
-        private Tuple<Guid, ContainerInfo> MapToEngineeringModelContainmentInfo(NpgsqlDataReader reader, string connectedPartition, string otherPartition)
+        private static Tuple<Guid, ContainerInfo> MapToEngineeringModelContainmentInfo(NpgsqlDataReader reader, string connectedPartition, string otherPartition)
         {
             var containedIid = (Guid)reader[ContainedIidKey];
 

--- a/CDP4Orm/Dao/Resolve/ResolveDao.cs
+++ b/CDP4Orm/Dao/Resolve/ResolveDao.cs
@@ -100,7 +100,7 @@ namespace CDP4Orm.Dao.Resolve
                 {
                     while (reader.Read())
                     {
-                        yield return this.MapToSiteDirectoryDto(reader);
+                        yield return MapToSiteDirectoryDto(reader);
                     }
                 }
             }
@@ -154,7 +154,7 @@ namespace CDP4Orm.Dao.Resolve
                 {
                     while (reader.Read())
                     {
-                        yield return this.MapToEngineeringModelDto(reader, connectedPartition, subPartition);
+                        yield return MapToEngineeringModelDto(reader, connectedPartition, subPartition);
                     }
                 }
             }
@@ -175,7 +175,7 @@ namespace CDP4Orm.Dao.Resolve
         /// <returns>
         /// A deserialized instance of <see cref="ContainerInfo"/>.
         /// </returns>
-        private ResolveInfo MapToEngineeringModelDto(NpgsqlDataReader reader, string connectedPartition, string subPartition)
+        private static ResolveInfo MapToEngineeringModelDto(NpgsqlDataReader reader, string connectedPartition, string subPartition)
         {
             var typeInfo = reader["TypeInfo"].ToString();
             var iid = (Guid)reader["Iid"];
@@ -197,7 +197,7 @@ namespace CDP4Orm.Dao.Resolve
         /// <returns>
         /// A deserialized instance of <see cref="ResolveInfo"/>.
         /// </returns>
-        private ResolveInfo MapToSiteDirectoryDto(NpgsqlDataReader reader)
+        private static ResolveInfo MapToSiteDirectoryDto(NpgsqlDataReader reader)
         {
             var typeInfo = reader["TypeInfo"].ToString();
             var iid = (Guid)reader["Iid"];

--- a/CDP4Orm/Dao/Revision/RevisionDao.cs
+++ b/CDP4Orm/Dao/Revision/RevisionDao.cs
@@ -176,7 +176,7 @@ namespace CDP4Orm.Dao.Revision
         {
             this.Logger.LogDebug("WriteRevision of {thing} to {partition} by {actor}", thing, partition, actor);
 
-            var table = this.GetThingRevisionTableName(thing);
+            var table = GetThingRevisionTableName(thing);
 
             var columns = string.Format("(\"{0}\", \"{1}\", \"{2}\", \"{3}\", \"{4}\")", IidKey, RevisionColumnName, InstantColumn, ActorColumn, JsonColumnName);
             var values = "(:iid, :revisionnumber, \"SiteDirectory\".get_transaction_time(), :actor, :jsonb)";
@@ -216,7 +216,7 @@ namespace CDP4Orm.Dao.Revision
 
             if (resolveInfo != null)
             {
-                var revisionTableName = this.GetThingRevisionTableName(resolveInfo);
+                var revisionTableName = GetThingRevisionTableName(resolveInfo);
 
                 var sqlQuery = string.Format(
                     "SELECT \"{0}\" FROM \"{1}\".\"{2}\" WHERE \"{3}\" = :iid AND \"{4}\" >= :fromrevision AND \"{4}\" <= :torevision",
@@ -389,7 +389,7 @@ namespace CDP4Orm.Dao.Revision
             {
                 using (var reader = command.ExecuteReader())
                 {
-                    return this.MapToRevisionRegistryInfoList(reader).ToList();
+                    return MapToRevisionRegistryInfoList(reader).ToList();
                 }
             }
         }
@@ -403,7 +403,7 @@ namespace CDP4Orm.Dao.Revision
         /// <returns>
         /// Enumerable of <see cref="RevisionRegistryInfo"/>.
         /// </returns>
-        private IEnumerable<RevisionRegistryInfo> MapToRevisionRegistryInfoList(NpgsqlDataReader reader)
+        private static IEnumerable<RevisionRegistryInfo> MapToRevisionRegistryInfoList(NpgsqlDataReader reader)
         {
             while (reader.Read())
             {
@@ -463,7 +463,7 @@ namespace CDP4Orm.Dao.Revision
                 {
                     while (reader.Read())
                     {
-                        yield return this.MapToSiteDirectoryRevisionInfo(reader, partition);
+                        yield return MapToSiteDirectoryRevisionInfo(reader, partition);
                     }
                 }
             }
@@ -481,7 +481,7 @@ namespace CDP4Orm.Dao.Revision
         /// <returns>
         /// A deserialized instance of <see cref="RevisionInfo"/>.
         /// </returns>
-        private RevisionInfo MapToSiteDirectoryRevisionInfo(NpgsqlDataReader reader, string connectedPartition)
+        private static RevisionInfo MapToSiteDirectoryRevisionInfo(NpgsqlDataReader reader, string connectedPartition)
         {
             var iid = (Guid)reader[IidKey];
             var typeInfo = reader[TypeInfoKey].ToString();
@@ -543,7 +543,7 @@ namespace CDP4Orm.Dao.Revision
                 {
                     while (reader.Read())
                     {
-                        yield return this.MapToEngineeringModelRevisionInfo(reader, connectedPartition, subPartition);
+                        yield return MapToEngineeringModelRevisionInfo(reader, connectedPartition, subPartition);
                     }
                 }
             }
@@ -564,7 +564,7 @@ namespace CDP4Orm.Dao.Revision
         /// <returns>
         /// A deserialized instance of <see cref="RevisionInfo"/>.
         /// </returns>
-        private RevisionInfo MapToEngineeringModelRevisionInfo(NpgsqlDataReader reader, string connectedPartition, string subPartition)
+        private static RevisionInfo MapToEngineeringModelRevisionInfo(NpgsqlDataReader reader, string connectedPartition, string subPartition)
         {
             var iid = (Guid)reader[IidKey];
             var typeInfo = reader[TypeInfoKey].ToString();
@@ -585,7 +585,7 @@ namespace CDP4Orm.Dao.Revision
         /// </summary>
         /// <param name="resolveInfo">The <see cref="ResolveInfo"/></param>
         /// <returns>The name of the revision table</returns>
-        private string GetThingRevisionTableName(ResolveInfo resolveInfo)
+        private static string GetThingRevisionTableName(ResolveInfo resolveInfo)
         {
             return resolveInfo.InstanceInfo.TypeName + RevisionTableSuffix;
         }
@@ -595,7 +595,7 @@ namespace CDP4Orm.Dao.Revision
         /// </summary>
         /// <param name="thing">The <see cref="Thing"/></param>
         /// <returns>The name of the revision table</returns>
-        private string GetThingRevisionTableName(Thing thing)
+        private static string GetThingRevisionTableName(Thing thing)
         {
             return thing.ClassKind + RevisionTableSuffix;
         }

--- a/CDP4Orm/Dao/Supplemental/IterationDao.cs
+++ b/CDP4Orm/Dao/Supplemental/IterationDao.cs
@@ -133,16 +133,16 @@ namespace CDP4Orm.Dao
         /// </param>
         public void MoveToNextIterationFromLast(NpgsqlTransaction transaction, string partition, Thing thing)
         {
-            this.UpdateContainment(transaction, partition, typeof(Option), thing);
-            this.UpdateContainment(transaction, partition, typeof(Publication), thing);
-            this.UpdateContainment(transaction, partition, typeof(PossibleFiniteStateList), thing);
-            this.UpdateContainment(transaction, partition, typeof(ElementDefinition), thing);
-            this.UpdateContainment(transaction, partition, typeof(Relationship), thing);
-            this.UpdateContainment(transaction, partition, typeof(ExternalIdentifierMap), thing);
-            this.UpdateContainment(transaction, partition, typeof(RequirementsSpecification), thing);
-            this.UpdateContainment(transaction, partition, typeof(DomainFileStore), thing);
-            this.UpdateContainment(transaction, partition, typeof(ActualFiniteStateList), thing);
-            this.UpdateContainment(transaction, partition, typeof(RuleVerificationList), thing);
+            UpdateContainment(transaction, partition, typeof(Option), thing);
+            UpdateContainment(transaction, partition, typeof(Publication), thing);
+            UpdateContainment(transaction, partition, typeof(PossibleFiniteStateList), thing);
+            UpdateContainment(transaction, partition, typeof(ElementDefinition), thing);
+            UpdateContainment(transaction, partition, typeof(Relationship), thing);
+            UpdateContainment(transaction, partition, typeof(ExternalIdentifierMap), thing);
+            UpdateContainment(transaction, partition, typeof(RequirementsSpecification), thing);
+            UpdateContainment(transaction, partition, typeof(DomainFileStore), thing);
+            UpdateContainment(transaction, partition, typeof(ActualFiniteStateList), thing);
+            UpdateContainment(transaction, partition, typeof(RuleVerificationList), thing);
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace CDP4Orm.Dao
         /// <param name="thing">
         /// The thing DTO that is to be persisted.
         /// </param>
-        private void UpdateContainment(NpgsqlTransaction transaction, string partition, Type containedType, Thing thing)
+        private static void UpdateContainment(NpgsqlTransaction transaction, string partition, Type containedType, Thing thing)
         {
             using (var command = new NpgsqlCommand())
             {

--- a/CDP4Orm/Dao/Supplemental/PublicationDao.cs
+++ b/CDP4Orm/Dao/Supplemental/PublicationDao.cs
@@ -40,7 +40,7 @@ namespace CDP4Orm.Dao
         /// <param name="partition">The current partition</param>
         public void DeleteAll(NpgsqlTransaction transaction, string partition)
         {
-            this.DeleteAll(transaction, partition, ClassKind.Publication.ToString());
+            DeleteAll(transaction, partition, ClassKind.Publication.ToString());
         }
     }
 }

--- a/CometServer.Tests/ChangeLog/ChangeLogTestFixture.cs
+++ b/CometServer.Tests/ChangeLog/ChangeLogTestFixture.cs
@@ -867,7 +867,7 @@ namespace CometServer.Tests.Services
 
             var things = new Thing[] { this.iteration, this.parameter, this.engineeringModel };
 
-            LogEntryChangelogItem[] createdLogEntries = { };
+            var createdLogEntries = Array.Empty<LogEntryChangelogItem>();
 
             this.operationProcessor.Setup(
                     x =>
@@ -948,7 +948,7 @@ namespace CometServer.Tests.Services
 
             var things = new Thing[] { this.parameterValueSet_1, this.engineeringModel };
 
-            LogEntryChangelogItem[] createdLogEntries = { };
+            var createdLogEntries = Array.Empty<LogEntryChangelogItem>();
 
             this.operationProcessor.Setup(
                     x =>
@@ -1030,7 +1030,7 @@ namespace CometServer.Tests.Services
 
             var things = new Thing[] { this.elementUsage_1, this.elementDefinition_1, this.engineeringModel };
 
-            LogEntryChangelogItem[] createdLogEntries = { };
+            var createdLogEntries = Array.Empty<LogEntryChangelogItem>();
 
             this.operationProcessor.Setup(
                     x =>
@@ -1124,7 +1124,7 @@ namespace CometServer.Tests.Services
 
             var things = new Thing[] { this.elementDefinition_1, this.engineeringModel };
 
-            LogEntryChangelogItem[] createdLogEntries = { };
+            var createdLogEntries = Array.Empty<LogEntryChangelogItem>();
 
             this.operationProcessor.Setup(
                     x =>
@@ -1202,7 +1202,7 @@ namespace CometServer.Tests.Services
 
             var things = new Thing[] { this.elementUsage_1, this.engineeringModel };
 
-            LogEntryChangelogItem[] createdLogEntries = { };
+            var createdLogEntries = Array.Empty<LogEntryChangelogItem>();
 
             this.operationProcessor.Setup(
                     x =>
@@ -1478,7 +1478,7 @@ namespace CometServer.Tests.Services
 
             var things = new Thing[] { this.parameterOverride, this.engineeringModel };
 
-            LogEntryChangelogItem[] createdLogEntries = { };
+            var createdLogEntries = Array.Empty<LogEntryChangelogItem>();
 
             this.operationProcessor.Setup(
                     x =>
@@ -1566,7 +1566,7 @@ namespace CometServer.Tests.Services
 
             var things = new Thing[] { this.parameterOverrideValueSet_1, this.engineeringModel, this.existingModelLogEntry };
 
-            LogEntryChangelogItem[] createdLogEntries = { };
+            var createdLogEntries = Array.Empty<LogEntryChangelogItem>();
 
             this.operationProcessor.Setup(
                     x =>
@@ -1850,7 +1850,7 @@ namespace CometServer.Tests.Services
 
             var things = new Thing[] { this.parameterSubscriptionValueSet_1, this.engineeringModel };
 
-            LogEntryChangelogItem[] createdLogEntries = { };
+            var createdLogEntries = Array.Empty<LogEntryChangelogItem>();
 
             this.operationProcessor.Setup(
                     x =>
@@ -2050,7 +2050,7 @@ namespace CometServer.Tests.Services
 
             var things = new Thing[] { this.parameterOverrideSubscriptionValueSet_1, this.engineeringModel };
 
-            LogEntryChangelogItem[] createdLogEntries = { };
+            var createdLogEntries = Array.Empty<LogEntryChangelogItem>();
 
             this.operationProcessor.Setup(
                     x =>

--- a/CometServer.Tests/OperationProcessorTestFixture.cs
+++ b/CometServer.Tests/OperationProcessorTestFixture.cs
@@ -275,7 +275,7 @@ namespace CometServer.Tests
             var metaInfo = new PossibleFiniteStateListMetaInfo();
 
             Assert.DoesNotThrow(
-                () => this.operationProcessor.OrderedItemListValidation(
+                () => OperationProcessor.OrderedItemListValidation(
                     null,
                     updatedItem,
                     new List<string> { "PossibleState" },
@@ -313,7 +313,7 @@ namespace CometServer.Tests
             var metaInfo = new PossibleFiniteStateListMetaInfo();
 
             var exception = Assert.Throws<BadRequestException>(
-                () => this.operationProcessor.OrderedItemListValidation(
+                () => OperationProcessor.OrderedItemListValidation(
                     null,
                     updatedItem,
                     new List<string> { "PossibleState" },
@@ -353,7 +353,7 @@ namespace CometServer.Tests
             var metaInfo = new PossibleFiniteStateListMetaInfo();
 
             var exception = Assert.Throws<BadRequestException>(
-                () => this.operationProcessor.OrderedItemListValidation(
+                () => OperationProcessor.OrderedItemListValidation(
                     null,
                     updatedItem,
                     new List<string> { "PossibleState" },
@@ -485,20 +485,20 @@ namespace CometServer.Tests
 
             Assert.Throws(
                 typeof(InvalidOperationException),
-                () => this.operationProcessor.ValidateUpdateOperations(postOperation));
+                () => OperationProcessor.ValidateUpdateOperations(postOperation));
 
             postOperation.Update.Clear();
             postOperation.Update.Add(updateObjectWithoutClassKind);
 
             Assert.Throws(
                 typeof(InvalidOperationException),
-                () => this.operationProcessor.ValidateUpdateOperations(postOperation));
+                () => OperationProcessor.ValidateUpdateOperations(postOperation));
 
             var completeUpdateObject = new ClasslessDTO() { { IidKey, Guid.NewGuid() }, { ClasskindKey, Guid.NewGuid() } };
             postOperation.Update.Clear();
             postOperation.Update.Add(completeUpdateObject);
 
-            Assert.DoesNotThrow(() => this.operationProcessor.ValidateUpdateOperations(postOperation));
+            Assert.DoesNotThrow(() => OperationProcessor.ValidateUpdateOperations(postOperation));
         }
 
         private List<Thing> copySourceDtos;

--- a/CometServer.Tests/OperationProcessorTestFixture.cs
+++ b/CometServer.Tests/OperationProcessorTestFixture.cs
@@ -503,6 +503,9 @@ namespace CometServer.Tests
 
         private List<Thing> copySourceDtos;
 
+        private static readonly string[] DefaultValueArray = new[] { "-" };
+
+
         [Test]
         public void VerifyCopyElementDefWorks()
         {
@@ -611,10 +614,10 @@ namespace CometServer.Tests
                     {
                         var vs = new ParameterValueSet(guid, 1)
                         {
-                            Manual = new ValueArray<string>(new [] { "-" }),
-                            Computed = new ValueArray<string>(new [] { "-" }),
-                            Reference = new ValueArray<string>(new [] { "-" }),
-                            Published = new ValueArray<string>(new [] { "-" })
+                            Manual = new ValueArray<string>(DefaultValueArray),
+                            Computed = new ValueArray<string>(DefaultValueArray),
+                            Reference = new ValueArray<string>(DefaultValueArray),
+                            Published = new ValueArray<string>(DefaultValueArray)
                         };
 
                         list.Add(vs);
@@ -632,10 +635,10 @@ namespace CometServer.Tests
                     {
                         var vs = new ParameterOverrideValueSet(guid, 1)
                         {
-                            Manual = new ValueArray<string>(new[] { "-" }),
-                            Computed = new ValueArray<string>(new[] { "-" }),
-                            Reference = new ValueArray<string>(new[] { "-" }),
-                            Published = new ValueArray<string>(new[] { "-" })
+                            Manual = new ValueArray<string>(DefaultValueArray),
+                            Computed = new ValueArray<string>(DefaultValueArray),
+                            Reference = new ValueArray<string>(DefaultValueArray),
+                            Published = new ValueArray<string>(DefaultValueArray)
                         };
 
                         list.Add(vs);

--- a/CometServer.Tests/Services/BusinessLogic/ParameterOverrideValueSetFactoryTestFixture.cs
+++ b/CometServer.Tests/Services/BusinessLogic/ParameterOverrideValueSetFactoryTestFixture.cs
@@ -45,10 +45,10 @@ namespace CometServer.Tests.Services.BusinessLogic
         [SetUp]
         public void SetUp()
         {
-            var defaultValues = this.createValues("-");
+            var defaultValues = CreateValues("-");
             this.defaultValueArray = new ValueArray<string>(defaultValues);
 
-            var nonDefaultValues = this.createValues("1");
+            var nonDefaultValues = CreateValues("1");
             this.nonDefaultValueArray = new ValueArray<string>(nonDefaultValues);
 
             this.parameterOverrideValueSetFactory = new ParameterOverrideValueSetFactory();
@@ -77,7 +77,7 @@ namespace CometServer.Tests.Services.BusinessLogic
             Assert.AreEqual(CDP4Common.EngineeringModelData.ParameterSwitchKind.MANUAL, parameterOverrideValueSet.ValueSwitch);
         }
 
-        private IEnumerable<string> createValues(string value)
+        private static IEnumerable<string> CreateValues(string value)
         {
             var defaultValue = new List<string>(3);
             for (var i = 0; i < 3; i++)

--- a/CometServer.Tests/Services/BusinessLogic/ParameterSubscriptionValueSetFactoryTestFixture.cs
+++ b/CometServer.Tests/Services/BusinessLogic/ParameterSubscriptionValueSetFactoryTestFixture.cs
@@ -45,10 +45,10 @@ namespace CometServer.Tests.Services.BusinessLogic
         [SetUp]
         public void SetUp()
         {
-            var defaultValues = this.createValues("-");
+            var defaultValues = CreateValues("-");
             this.defaultValueArray = new ValueArray<string>(defaultValues);
 
-            var nonDefaultValues = this.createValues("1");
+            var nonDefaultValues = CreateValues("1");
             this.nonDefaultValueArray = new ValueArray<string>(nonDefaultValues);
 
             this.parameterSubscriptionValueSetFactory = new ParameterSubscriptionValueSetFactory();
@@ -72,7 +72,7 @@ namespace CometServer.Tests.Services.BusinessLogic
             Assert.AreEqual(CDP4Common.EngineeringModelData.ParameterSwitchKind.MANUAL, parameterSubscriptionValueSet.ValueSwitch);
         }
 
-        private IEnumerable<string> createValues(string value)
+        private static IEnumerable<string> CreateValues(string value)
         {
             var defaultValue = new List<string>(3);
             for (var i = 0; i < 3; i++)

--- a/CometServer.Tests/Services/BusinessLogic/ParameterValueSetFactoryTestFixture.cs
+++ b/CometServer.Tests/Services/BusinessLogic/ParameterValueSetFactoryTestFixture.cs
@@ -45,10 +45,10 @@ namespace CometServer.Tests.Services.BusinessLogic
         [SetUp]
         public void SetUp()
         {
-            var defaultValues = this.createValues("-");
+            var defaultValues = CreateValues("-");
             this.defaultValueArray = new ValueArray<string>(defaultValues);
 
-            var nonDefaultValues = this.createValues("1");
+            var nonDefaultValues = CreateValues("1");
             this.nonDefaultValueArray = new ValueArray<string>(nonDefaultValues);
 
             this.parameterValueSetFactory = new ParameterValueSetFactory();
@@ -79,7 +79,7 @@ namespace CometServer.Tests.Services.BusinessLogic
             Assert.AreEqual(CDP4Common.EngineeringModelData.ParameterSwitchKind.MANUAL, parameterValueSet.ValueSwitch);
         }
 
-        private IEnumerable<string> createValues(string value)
+        private static IEnumerable<string> CreateValues(string value)
         {
             var defaultValue = new List<string>(3);
             for (var i = 0; i < 3; i++)

--- a/CometServer.Tests/Services/Supplemental/IterationServiceTestFixture.cs
+++ b/CometServer.Tests/Services/Supplemental/IterationServiceTestFixture.cs
@@ -68,7 +68,7 @@ namespace CometServer.Tests.Services.Supplemental
         }
 
         [Test]
-        public void TestGetActiveIteration()
+        public void Verify_that_GetActiveIteration_returns_the_expected_result()
         {
             var setup1 = new IterationSetup(Guid.NewGuid(), 0) {IterationIid = Guid.NewGuid(), FrozenOn = DateTime.Now };
             var setup2 = new IterationSetup(Guid.NewGuid(), 0) {IterationIid = Guid.NewGuid()};
@@ -81,7 +81,7 @@ namespace CometServer.Tests.Services.Supplemental
 
             var active = this.iterationService.GetActiveIteration(null, "", null);
 
-            Assert.AreEqual(active.Iid, it2.Iid);
+            Assert.That(it2.Iid, Is.EqualTo(active.Iid));
         }
     }
 }

--- a/CometServer.Tests/SideEffects/ArrayParameterTypeSideEffectTestFixture.cs
+++ b/CometServer.Tests/SideEffects/ArrayParameterTypeSideEffectTestFixture.cs
@@ -66,8 +66,6 @@ namespace CometServer.Tests.SideEffects
 
         private ArrayParameterType arrayParameterTypeB;
 
-        private ArrayParameterType arrayParameterTypeC;
-
         private BooleanParameterType booleanParameterTypeD;
 
         private ParameterTypeComponent parameterTypeComponentA;

--- a/CometServer.Tests/SideEffects/CompoundParameterTypeSideEffectTestFixture.cs
+++ b/CometServer.Tests/SideEffects/CompoundParameterTypeSideEffectTestFixture.cs
@@ -66,8 +66,6 @@ namespace CometServer.Tests.SideEffects
 
         private CompoundParameterType compoundParameterTypeB;
 
-        private CompoundParameterType compoundParameterTypeC;
-
         private BooleanParameterType booleanParameterTypeD;
 
         private ParameterTypeComponent parameterTypeComponentA;

--- a/CometServer.Tests/SideEffects/DerivedUnitSideEffectTestFixture.cs
+++ b/CometServer.Tests/SideEffects/DerivedUnitSideEffectTestFixture.cs
@@ -64,8 +64,6 @@ namespace CometServer.Tests.SideEffects
 
         private DerivedUnit derivedUnitB;
 
-        private DerivedUnit derivedUnitC;
-
         private SimpleUnit simpleUnitD;
 
         private UnitFactor unitFactorA;

--- a/CometServer/Authorization/CredentialsService.cs
+++ b/CometServer/Authorization/CredentialsService.cs
@@ -193,7 +193,7 @@ namespace CometServer.Authorization
             var personOrganizationalParticipants = new List<OrganizationalParticipant>();
 
             // get org participation if the models have it enabled and person is part of an organization
-            if (allOrganizationalParticipants.Any() && person.Organization != null)
+            if (allOrganizationalParticipants.Count != 0 && person.Organization != null)
             {
                 personOrganizationalParticipants = this.GetPersonOrganizationalParticipants(person.Organization.Value, allOrganizationalParticipants, transaction);
             }
@@ -244,13 +244,13 @@ namespace CometServer.Authorization
             var allOrganizationalParticipants = engineeringModelSetups.SelectMany(ems => ems.OrganizationalParticipant).ToList();
 
             // get org participation if the models have it enabled and person is part of an organization
-            if (allOrganizationalParticipants.Any() && this.credentials.OrganizationIid != null)
+            if (allOrganizationalParticipants.Count != 0 && this.credentials.OrganizationIid != null)
             {
                 var personOrganizationalParticipants = this.GetPersonOrganizationalParticipants(this.credentials.OrganizationIid.Value, allOrganizationalParticipants, transaction);
                 this.credentials.OrganizationalParticipants = personOrganizationalParticipants;
             }
 
-            if (this.credentials.EngineeringModelSetup.OrganizationalParticipant.Any() && this.credentials.OrganizationIid != null && this.credentials.OrganizationalParticipants.Any())
+            if (this.credentials.EngineeringModelSetup.OrganizationalParticipant.Count != 0 && this.credentials.OrganizationIid != null && this.credentials.OrganizationalParticipants.Any())
             {
                 // transient settings for the particular EMS
                 // find the org participant

--- a/CometServer/Authorization/ObfuscationService.cs
+++ b/CometServer/Authorization/ObfuscationService.cs
@@ -122,7 +122,7 @@ namespace CometServer.Authorization
                 var affectedItemHashSet = new HashSet<Guid>(modelLogEntry.AffectedItemIid);
                 affectedItemHashSet.IntersectWith(this.obfuscatedCache);
 
-                if (!affectedItemHashSet.Any())
+                if (affectedItemHashSet.Count == 0)
                 {
                     continue;
                 }

--- a/CometServer/Authorization/OrganizationalParticipationResolverService.cs
+++ b/CometServer/Authorization/OrganizationalParticipationResolverService.cs
@@ -144,7 +144,7 @@ namespace CometServer.Authorization
                 return;
             }
 
-            if (this.CredentialsService.Credentials != null && this.CredentialsService.Credentials.EngineeringModelSetup.OrganizationalParticipant.Any() && !this.CredentialsService.Credentials.IsDefaultOrganizationalParticipant)
+            if (this.CredentialsService.Credentials != null && this.CredentialsService.Credentials.EngineeringModelSetup.OrganizationalParticipant.Count != 0 && !this.CredentialsService.Credentials.IsDefaultOrganizationalParticipant)
             {
                 if (this.CredentialsService.Credentials.OrganizationalParticipant == null)
                 {

--- a/CometServer/Authorization/PermissionService.cs
+++ b/CometServer/Authorization/PermissionService.cs
@@ -334,7 +334,7 @@ namespace CometServer.Authorization
                     case PersonAccessRightKind.MODIFY_IF_PARTICIPANT:
                         {
                             return this.IsEngineeringModelSetupModifyAllowed(thing, modifyOperation) || 
-                                   this.IsCreateAllowedForOperationOnThing(thing, modifyOperation);
+                                   IsCreateAllowedForOperationOnThing(thing, modifyOperation);
                         }
 
                     case PersonAccessRightKind.MODIFY_OWN_PERSON:
@@ -459,7 +459,7 @@ namespace CometServer.Authorization
         /// <param name="thing">The <see cref="Thing"/> to check</param>
         /// <param name="modifyOperation">The kind of operation we are performing</param>
         /// <returns>True if create is allowed, otherwise false</returns>
-        private bool IsCreateAllowedForOperationOnThing(Thing thing, string modifyOperation)
+        private static bool IsCreateAllowedForOperationOnThing(Thing thing, string modifyOperation)
         {
             return modifyOperation == CreateOperation && thing is EngineeringModelSetup;
         }

--- a/CometServer/Authorization/PermissionService.cs
+++ b/CometServer/Authorization/PermissionService.cs
@@ -364,7 +364,7 @@ namespace CometServer.Authorization
             }
 
             // obfuscation check. Regardless of other things, if a Thing is obfuscated for person, disallow write
-            if (this.CredentialsService.Credentials.EngineeringModelSetup.OrganizationalParticipant.Any() && (
+            if (this.CredentialsService.Credentials.EngineeringModelSetup.OrganizationalParticipant.Count != 0 && (
                     thing.ClassKind == ClassKind.ElementDefinition ||
                     thing.ClassKind == ClassKind.ElementUsage ||
                     thing.ClassKind == ClassKind.Parameter ||

--- a/CometServer/ChangeNotification/ChangeNoticationService.cs
+++ b/CometServer/ChangeNotification/ChangeNoticationService.cs
@@ -157,7 +157,7 @@ namespace CometServer.ChangeNotification
 
                         var changeNotificationSubscriptionUserPreferences = this.GetChangeLogSubscriptionUserPreferences(transaction, person);
 
-                        var endDateTime = this.GetEndDateTime(DayOfWeek.Monday);
+                        var endDateTime = GetEndDateTime(DayOfWeek.Monday);
                         var startDateTime = endDateTime.AddDays(-7);
                         var htmlStringBuilder = new StringBuilder();
                         var textStringBuilder = new StringBuilder();
@@ -255,7 +255,7 @@ namespace CometServer.ChangeNotification
         /// <returns>
         /// The end <see cref="DateTime"/>
         /// </returns>
-        private DateTime GetEndDateTime(DayOfWeek dayOfWeek)
+        private static DateTime GetEndDateTime(DayOfWeek dayOfWeek)
         {
             var dt = DateTime.UtcNow;
             var diff = (7 + (dt.DayOfWeek - dayOfWeek)) % 7;

--- a/CometServer/ChangeNotification/ChangeNoticationService.cs
+++ b/CometServer/ChangeNotification/ChangeNoticationService.cs
@@ -150,7 +150,7 @@ namespace CometServer.ChangeNotification
 
                         var emailAddresses = this.GetEmailAdressess(transaction, person).ToList();
 
-                        if (!emailAddresses.Any())
+                        if (emailAddresses.Count == 0)
                         {
                             continue;
                         }
@@ -167,7 +167,7 @@ namespace CometServer.ChangeNotification
 
                         foreach (var changeNotificationSubscriptionUserPreference in changeNotificationSubscriptionUserPreferences)
                         {
-                            if (changeNotificationSubscriptionUserPreference.Value.ChangeNotificationSubscriptions.Any()
+                            if (changeNotificationSubscriptionUserPreference.Value.ChangeNotificationSubscriptions.Count != 0
                                 && changeNotificationSubscriptionUserPreference.Value.ChangeNotificationReportType != ChangeNotificationReportType.None)
                             {
                                 var changelogSections = changelogBodyComposer.CreateChangelogSections(
@@ -223,7 +223,7 @@ namespace CometServer.ChangeNotification
         /// </returns>
         private IEnumerable<EmailAddress> GetEmailAdressess(NpgsqlTransaction transaction, Person person)
         {
-            if (!person.EmailAddress.Any())
+            if (person.EmailAddress.Count == 0)
             {
                 yield break;
             }
@@ -231,7 +231,7 @@ namespace CometServer.ChangeNotification
             var emailAddressDao = this.container.Resolve<IEmailAddressDao>();
             var emailAddresses = emailAddressDao.Read(transaction, "SiteDirectory", person.EmailAddress).ToList();
 
-            if (!emailAddresses.Any())
+            if (emailAddresses.Count == 0)
             {
                 yield break;
             }

--- a/CometServer/ChangeNotification/ChangelogBodyComposer.cs
+++ b/CometServer/ChangeNotification/ChangelogBodyComposer.cs
@@ -154,7 +154,7 @@ namespace CometServer.ChangeNotification
                     .Where(x => x.Person == person.Iid && x.IsActive)
                     .ToList();
 
-            if (!participants.Any())
+            if (participants.Count == 0)
             {
                 yield return CreateParticipantNotActiveSection(engineeringModelSetup);
 
@@ -166,7 +166,7 @@ namespace CometServer.ChangeNotification
                     .Where(x => engineeringModelSetup.Participant.Contains(x.Iid))
                     .ToList();
 
-            if (!engineeringModelParticipants.Any())
+            if (engineeringModelParticipants.Count == 0)
             {
                 yield return CreateNoEngineeringModelParticipantSection(engineeringModelSetup);
 
@@ -179,7 +179,7 @@ namespace CometServer.ChangeNotification
                     .Distinct()
                     .ToList();
 
-            if (!domains.Any())
+            if (domains.Count == 0)
             {
                 yield return CreateNoDomainOfExpertiseSection(engineeringModelSetup);
 
@@ -196,7 +196,7 @@ namespace CometServer.ChangeNotification
                         && x.ModifiedOn < endDateTime)
                     .ToList();
 
-            if (!modelLogEntries.Any() || !modelLogEntries.SelectMany(x => x.LogEntryChangelogItem).Any())
+            if (modelLogEntries.Count == 0 || !modelLogEntries.SelectMany(x => x.LogEntryChangelogItem).Any())
             {
                 yield return CreateNoModelLogEntriesSection(engineeringModelSetup);
 

--- a/CometServer/ChangeNotification/ChangelogBodyComposer.cs
+++ b/CometServer/ChangeNotification/ChangelogBodyComposer.cs
@@ -140,7 +140,7 @@ namespace CometServer.ChangeNotification
 
             if (engineeringModelSetup == null)
             {
-                yield return this.CreateEngineeringModelNotFoundSection(changeNotificationSubscriptionUserPreference);
+                yield return CreateEngineeringModelNotFoundSection(changeNotificationSubscriptionUserPreference);
 
                 yield break;
             }
@@ -156,7 +156,7 @@ namespace CometServer.ChangeNotification
 
             if (!participants.Any())
             {
-                yield return this.CreateParticipantNotActiveSection(engineeringModelSetup);
+                yield return CreateParticipantNotActiveSection(engineeringModelSetup);
 
                 yield break;
             }
@@ -168,7 +168,7 @@ namespace CometServer.ChangeNotification
 
             if (!engineeringModelParticipants.Any())
             {
-                yield return this.CreateNoEngineeringModelParticipantSection(engineeringModelSetup);
+                yield return CreateNoEngineeringModelParticipantSection(engineeringModelSetup);
 
                 yield break;
             }
@@ -181,7 +181,7 @@ namespace CometServer.ChangeNotification
 
             if (!domains.Any())
             {
-                yield return this.CreateNoDomainOfExpertiseSection(engineeringModelSetup);
+                yield return CreateNoDomainOfExpertiseSection(engineeringModelSetup);
 
                 yield break;
             }
@@ -198,19 +198,19 @@ namespace CometServer.ChangeNotification
 
             if (!modelLogEntries.Any() || !modelLogEntries.SelectMany(x => x.LogEntryChangelogItem).Any())
             {
-                yield return this.CreateNoModelLogEntriesSection(engineeringModelSetup);
+                yield return CreateNoModelLogEntriesSection(engineeringModelSetup);
 
                 yield break;
             }
 
             if (!modelLogEntries.Any(x => x.AffectedDomainIid.Intersect(domains).Any()))
             {
-                yield return this.CreateNoRelevantChangesFoundSection(engineeringModelSetup);
+                yield return CreateNoRelevantChangesFoundSection(engineeringModelSetup);
 
                 yield break;
             }
 
-            var filteredModelLogEntries = this.FilterDomains(modelLogEntries, domains);
+            var filteredModelLogEntries = FilterDomains(modelLogEntries, domains);
 
             var modelLogEntryDataCreator = container.Resolve<IModelLogEntryDataCreator>();
 
@@ -259,7 +259,7 @@ namespace CometServer.ChangeNotification
         /// <returns>
         /// The filtered <see cref="List{T}"/> of type <see cref="ModelLogEntry"/>.
         /// </returns>
-        private List<ModelLogEntry> FilterDomains(List<ModelLogEntry> modelLogEntries, List<Guid> domains)
+        private static List<ModelLogEntry> FilterDomains(List<ModelLogEntry> modelLogEntries, List<Guid> domains)
         {
             return modelLogEntries.Where(x => x.AffectedDomainIid.Intersect(domains).Any()).ToList();
         }
@@ -273,7 +273,7 @@ namespace CometServer.ChangeNotification
         /// <returns>
         /// The created <see cref="ChangelogSection"/>
         /// </returns>
-        private ChangelogSection CreateNoRelevantChangesFoundSection(EngineeringModelSetup engineeringModelSetup)
+        private static ChangelogSection CreateNoRelevantChangesFoundSection(EngineeringModelSetup engineeringModelSetup)
         {
             return new ChangelogSection(
                 $"{engineeringModelSetup.Name}",
@@ -290,7 +290,7 @@ namespace CometServer.ChangeNotification
         /// <returns>
         /// The created <see cref="ChangelogSection"/>
         /// </returns>
-        private ChangelogSection CreateNoModelLogEntriesSection(EngineeringModelSetup engineeringModelSetup)
+        private static ChangelogSection CreateNoModelLogEntriesSection(EngineeringModelSetup engineeringModelSetup)
         {            
             return new ChangelogSection(
                 $"{engineeringModelSetup.Name}", 
@@ -308,7 +308,7 @@ namespace CometServer.ChangeNotification
         /// <returns>
         /// The created <see cref="ChangelogSection"/>
         /// </returns>
-        private ChangelogSection CreateNoDomainOfExpertiseSection(EngineeringModelSetup engineeringModelSetup)
+        private static ChangelogSection CreateNoDomainOfExpertiseSection(EngineeringModelSetup engineeringModelSetup)
         {
             return new ChangelogSection(
                     $"{engineeringModelSetup.Name}", 
@@ -325,7 +325,7 @@ namespace CometServer.ChangeNotification
         /// <returns>
         /// The created <see cref="ChangelogSection"/>
         /// </returns>
-        private ChangelogSection CreateNoEngineeringModelParticipantSection(EngineeringModelSetup engineeringModelSetup)
+        private static ChangelogSection CreateNoEngineeringModelParticipantSection(EngineeringModelSetup engineeringModelSetup)
         {
             return new ChangelogSection(
                     $"{engineeringModelSetup.Name}", 
@@ -342,7 +342,7 @@ namespace CometServer.ChangeNotification
         /// <returns>
         /// The created <see cref="ChangelogSection"/>
         /// </returns>
-        private ChangelogSection CreateParticipantNotActiveSection(EngineeringModelSetup engineeringModelSetup)
+        private static ChangelogSection CreateParticipantNotActiveSection(EngineeringModelSetup engineeringModelSetup)
         {
             return 
                 new ChangelogSection(
@@ -360,7 +360,7 @@ namespace CometServer.ChangeNotification
         /// <returns>
         /// The created <see cref="ChangelogSection"/>
         /// </returns>
-        private ChangelogSection CreateEngineeringModelNotFoundSection(ChangeNotificationSubscriptionUserPreference changeNotificationSubscriptionUserPreference)
+        private static ChangelogSection CreateEngineeringModelNotFoundSection(ChangeNotificationSubscriptionUserPreference changeNotificationSubscriptionUserPreference)
         {
             return 
                 new ChangelogSection(

--- a/CometServer/ChangeNotification/Data/ModelLogEntryDataCreator.cs
+++ b/CometServer/ChangeNotification/Data/ModelLogEntryDataCreator.cs
@@ -88,7 +88,7 @@ namespace CometServer.ChangeNotification.Data
 
             foreach (var changeNotificationSubscription in changeNotificationSubscriptionUserPreference.ChangeNotificationSubscriptions)
             {
-                var changeNotificationFilter = this.CreateChangeLogNotificationFilter(changeNotificationSubscription, domainOfExpertises);
+                var changeNotificationFilter = CreateChangeLogNotificationFilter(changeNotificationSubscription, domainOfExpertises);
 
                 foreach (var modelLogEntry in modelLogEntries.OrderBy(x => x.CreatedOn))
                 {
@@ -132,7 +132,7 @@ namespace CometServer.ChangeNotification.Data
         /// <returns>
         /// The <see cref="IChangeNotificationFilter"/>
         /// </returns>
-        private IChangeNotificationFilter CreateChangeLogNotificationFilter(ChangeNotificationSubscription changeNotificationSubscription, IEnumerable<DomainOfExpertise> domainOfExpertises)
+        private static IChangeNotificationFilter CreateChangeLogNotificationFilter(ChangeNotificationSubscription changeNotificationSubscription, IEnumerable<DomainOfExpertise> domainOfExpertises)
         {
             switch (changeNotificationSubscription.ChangeNotificationSubscriptionType)
             {

--- a/CometServer/Helpers/Cdp4TransactionManager.cs
+++ b/CometServer/Helpers/Cdp4TransactionManager.cs
@@ -345,7 +345,7 @@ namespace CometServer.Helpers
         /// </param>
         public void SetIterationContext(NpgsqlTransaction transaction, string partition)
         {
-            this.ApplyIterationContext(transaction, partition, this.IterationSetup);
+            ApplyIterationContext(transaction, partition, this.IterationSetup);
         }
 
         /// <summary>
@@ -383,8 +383,8 @@ namespace CometServer.Helpers
         private NpgsqlTransaction GetTransaction(ref NpgsqlConnection connection, Credentials credentials)
         {
             var transaction = this.SetupNewTransaction(ref connection);
-            this.CreateTransactionInfoTable(transaction);
-            this.CreateDefaultTransactionInfoEntry(transaction, credentials);
+            CreateTransactionInfoTable(transaction);
+            CreateDefaultTransactionInfoEntry(transaction, credentials);
 
             return transaction;
         }
@@ -401,7 +401,7 @@ namespace CometServer.Helpers
         /// <param name="iterationSetup">
         /// The iteration Setup.
         /// </param>
-        private void ApplyIterationContext(NpgsqlTransaction transaction, string partition, IterationSetup iterationSetup)
+        private static void ApplyIterationContext(NpgsqlTransaction transaction, string partition, IterationSetup iterationSetup)
         {
             if (iterationSetup == null)
             {
@@ -479,14 +479,14 @@ namespace CometServer.Helpers
         /// <param name="credentials">
         /// The credentials.
         /// </param>
-        private void CreateDefaultTransactionInfoEntry(NpgsqlTransaction transaction, Credentials credentials)
+        private static void CreateDefaultTransactionInfoEntry(NpgsqlTransaction transaction, Credentials credentials)
         {
             // insert actor from the request credentials otherwise use default (null) user
             var sqlBuilder = new StringBuilder();
             var isCredentialSet = credentials != null;
 
             sqlBuilder.AppendFormat("INSERT INTO {0} ({1}, {2})", TransactionInfoTable, UserIdColumn, TransactionTimeColumn);
-            sqlBuilder.AppendFormat(" VALUES({0}, statement_timestamp());", isCredentialSet ? string.Format(":{0}", UserIdColumn) : "null");
+            sqlBuilder.AppendFormat(" VALUES({0}, statement_timestamp());", isCredentialSet ? $":{UserIdColumn}" : "null");
 
             using (var command = new NpgsqlCommand(sqlBuilder.ToString(), transaction.Connection, transaction))
             {
@@ -505,7 +505,7 @@ namespace CometServer.Helpers
         /// <param name="transaction">
         /// The current transaction to the database.
         /// </param>
-        private void CreateTransactionInfoTable(NpgsqlTransaction transaction)
+        private static void CreateTransactionInfoTable(NpgsqlTransaction transaction)
         {
             // setup transaction_info table that is valid only for this transaction
             var sqlBuilder = new StringBuilder();

--- a/CometServer/Modules/10-25/ApiBase.cs
+++ b/CometServer/Modules/10-25/ApiBase.cs
@@ -278,7 +278,7 @@ namespace CometServer.Modules
                         partition,
                         new[] { identifier },
                         authorizedContext).ToList();
-                    if (!resource.Any())
+                    if (resource.Count == 0)
                     {
                         continue;
                     }
@@ -714,7 +714,7 @@ namespace CometServer.Modules
         /// </param>
         private void PrepareMultiPartResponse(IMetaInfoProvider metaInfoProvider, ICdp4JsonSerializer jsonSerializer, IFileBinaryService fileBinaryService, IPermissionInstanceFilterService permissionInstanceFilterService, Stream targetStream, List<FileRevision> fileRevisions, List<Thing> resourceResponse, Version requestDataModelVersion)
         {
-            if (!fileRevisions.Any())
+            if (fileRevisions.Count == 0)
             {
                 // do nothing if no file revisions are present
                 return;

--- a/CometServer/Modules/10-25/ApiBase.cs
+++ b/CometServer/Modules/10-25/ApiBase.cs
@@ -543,12 +543,12 @@ namespace CometServer.Modules
             IProcessor processor,
             EngineeringModelSetup modelSetup)
         {
-            var securityContext = this.SetupSecurityContextForLibraryRead(requestUtils);
+            var securityContext = SetupSecurityContextForLibraryRead(requestUtils);
 
             // retrieve the required model reference data library
             var modelReferenceDataLibraryData = processor.GetResource(ModelReferenceDataLibraryType, SiteDirectoryData, modelSetup.RequiredRdl, securityContext);
 
-            return this.RetrieveChainedReferenceData(requestUtils, processor, securityContext, modelReferenceDataLibraryData);
+            return RetrieveChainedReferenceData(requestUtils, processor, securityContext, modelReferenceDataLibraryData);
         }
 
         /// <summary>
@@ -568,12 +568,12 @@ namespace CometServer.Modules
         /// </returns>
         protected IEnumerable<Thing> CollectReferenceDataLibraryChain(IRequestUtils requestUtils, IProcessor processor, ModelReferenceDataLibrary modelReferenceDataLibrary)
         {
-            var securityContext = this.SetupSecurityContextForLibraryRead(requestUtils);
+            var securityContext = SetupSecurityContextForLibraryRead(requestUtils);
 
             // retrieve the required model reference data library with extent = deep
             var modelReferenceDataLibraryData = processor.GetResource(ModelReferenceDataLibraryType, SiteDirectoryData, new[] { modelReferenceDataLibrary.Iid }, securityContext);
 
-            return this.RetrieveChainedReferenceData(requestUtils, processor, securityContext, modelReferenceDataLibraryData)
+            return RetrieveChainedReferenceData(requestUtils, processor, securityContext, modelReferenceDataLibraryData)
                 .Where(x => x.Iid != modelReferenceDataLibrary.Iid);
         }
 
@@ -760,7 +760,7 @@ namespace CometServer.Modules
 
             // stream the multipart content to the request contents target stream
             content.CopyToAsync(targetStream).Wait();
-            this.AddMultiPartMimeEndpoint(targetStream);
+            AddMultiPartMimeEndpoint(targetStream);
         }
 
         /// <summary>
@@ -837,7 +837,7 @@ namespace CometServer.Modules
                 // stream the multipart content to the request contents target stream
                 content.CopyToAsync(targetStream).Wait();
 
-                this.AddMultiPartMimeEndpoint(targetStream);
+                AddMultiPartMimeEndpoint(targetStream);
             }
             finally
             {
@@ -852,7 +852,7 @@ namespace CometServer.Modules
         /// <remarks>
         /// Changes the <param name="targetStream"></param>
         /// </remarks>
-        private void AddMultiPartMimeEndpoint(Stream targetStream)
+        private static void AddMultiPartMimeEndpoint(Stream targetStream)
         {
             var endLine = Encoding.Default.GetBytes($"\r\n--{HttpConstants.BoundaryString}--");
             targetStream.Write(endLine, 0, endLine.Length);
@@ -867,7 +867,7 @@ namespace CometServer.Modules
         /// <returns>
         /// The <see cref="RequestSecurityContext"/>.
         /// </returns>
-        private RequestSecurityContext SetupSecurityContextForLibraryRead(IRequestUtils requestUtils)
+        private static RequestSecurityContext SetupSecurityContextForLibraryRead(IRequestUtils requestUtils)
         {
             // override query parameters to return full set
             requestUtils.OverrideQueryParameters =
@@ -894,7 +894,7 @@ namespace CometServer.Modules
         /// <returns>
         /// A collection of retrieved reference data.
         /// </returns>
-        private IEnumerable<Thing> RetrieveChainedReferenceData(IRequestUtils requestUtils, IProcessor processor, ISecurityContext securityContext, IEnumerable<Thing> modelReferenceDataLibraryData)
+        private static IEnumerable<Thing> RetrieveChainedReferenceData(IRequestUtils requestUtils, IProcessor processor, ISecurityContext securityContext, IEnumerable<Thing> modelReferenceDataLibraryData)
         {
             var chainedReferenceDataColl = new List<Thing>();
 

--- a/CometServer/Modules/10-25/EngineeringModelApi.cs
+++ b/CometServer/Modules/10-25/EngineeringModelApi.cs
@@ -307,7 +307,7 @@ namespace CometServer.Modules
                     // gather all Things as indicated by the request URI 
                     resourceResponse.AddRange(this.GetContainmentResponse(requestUtils, transactionManager, processor, partition, modelSetup, routeSegments));
 
-                    if (!resourceResponse.Any())
+                    if (resourceResponse.Count == 0)
                     {
                         httpResponse.StatusCode = (int)HttpStatusCode.BadRequest;
                         await httpResponse.AsJson("The identifier of the object to query was not found or the route is invalid.");
@@ -351,7 +351,7 @@ namespace CometServer.Modules
                 this.logger.LogInformation("{requestToken} completed in {sw} [ms]", requestToken, sw.ElapsedMilliseconds);
 
                 // obfuscate if needed
-                if (modelSetup.OrganizationalParticipant.Any())
+                if (modelSetup.OrganizationalParticipant.Count != 0)
                 {
                     sw = new Stopwatch();
                     sw.Start();

--- a/CometServer/Modules/10-25/EngineeringModelApi.cs
+++ b/CometServer/Modules/10-25/EngineeringModelApi.cs
@@ -256,7 +256,7 @@ namespace CometServer.Modules
                     : transactionManager.SetupTransaction(ref connection, credentials);
 
                 var processor = new ResourceProcessor(transaction, serviceProvider, requestUtils, metaInfoProvider);
-                var modelSetup = this.DetermineEngineeringModelSetup(requestUtils, transactionManager, processor, routeSegments);
+                var modelSetup = DetermineEngineeringModelSetup(requestUtils, transactionManager, processor, routeSegments);
                 var partition = requestUtils.GetEngineeringModelPartitionString(modelSetup.EngineeringModelIid);
 
                 // set the participant information
@@ -331,7 +331,7 @@ namespace CometServer.Modules
                         return;
                     }
 
-                    resourceResponse = this.CherryPick(requestUtils, cherryPickService, containmentService, resourceResponse);
+                    resourceResponse = CherryPick(requestUtils, cherryPickService, containmentService, resourceResponse);
                 }
                 else if (requestUtils.QueryParameters.ClassKinds.Any())
                 {
@@ -462,7 +462,7 @@ namespace CometServer.Modules
         /// The <see cref="IRequestUtils"/> that provides utilities that are valid for the current HttpRequest handling
         /// </param>
         /// <returns></returns>
-        private List<Thing> CherryPick(IRequestUtils requestUtils, ICherryPickService cherryPickService, IContainmentService containmentService, IReadOnlyList<Thing> resourceResponse)
+        private static List<Thing> CherryPick(IRequestUtils requestUtils, ICherryPickService cherryPickService, IContainmentService containmentService, IReadOnlyList<Thing> resourceResponse)
         {
             var cherryPickedThings = cherryPickService.CherryPick(resourceResponse, requestUtils.QueryParameters.ClassKinds, requestUtils.QueryParameters.CategoriesId)
                 .ToList();
@@ -545,7 +545,7 @@ namespace CometServer.Modules
                     await httpRequest.Body.CopyToAsync(requestStream);
 
                     bodyStream = await this.ExtractJsonBodyStreamFromMultiPartMessage(requestStream, multiPartBoundary);
-                    fileDictionary = await this.ExtractFilesFromMultipartMessage(fileBinaryService, requestStream, multiPartBoundary);
+                    fileDictionary = await ExtractFilesFromMultipartMessage(fileBinaryService, requestStream, multiPartBoundary);
 
                     // - New File: 
                     //      create -> File, FileRevision
@@ -581,7 +581,7 @@ namespace CometServer.Modules
 
                 var resourceProcessor = new ResourceProcessor(transaction, serviceProvider, requestUtils, metaInfoProvider);
 
-                var modelSetup = this.DetermineEngineeringModelSetup(requestUtils, transactionManager, resourceProcessor, routeSegments);
+                var modelSetup = DetermineEngineeringModelSetup(requestUtils, transactionManager, resourceProcessor, routeSegments);
 
                 var partition = requestUtils.GetEngineeringModelPartitionString(modelSetup.EngineeringModelIid);
 
@@ -591,7 +591,7 @@ namespace CometServer.Modules
                     credentialsService.ResolveParticipantCredentials(transaction);
                     credentialsService.Credentials.IsParticipant = true;
 
-                    var iteration = this.DetermineIteration(resourceProcessor, partition, routeSegments);
+                    var iteration = DetermineIteration(resourceProcessor, partition, routeSegments);
                     credentialsService.Credentials.Iteration = iteration;
                 }
 
@@ -777,13 +777,19 @@ namespace CometServer.Modules
         /// <summary>
         /// Extracts the files from the multi-part message
         /// </summary>
+        /// <param name="fileBinaryService"> <see cref="IFileBinaryService"/> used to operate on files
+        /// The (injected) 
+        /// </param>
         /// <param name="stream">
         /// The <see cref="Stream"/> that contains the multi-part messsage
+        /// </param>
+        /// <param name="boundary">
+        /// The multipart boundary string.
         /// </param>
         /// <returns>
         /// A <see cref="Stream"/> that contains the posted multipart message
         /// </returns>
-        private async Task<Dictionary<string, Stream>> ExtractFilesFromMultipartMessage(IFileBinaryService fileBinaryService, Stream stream, string boundary)
+        private static async Task<Dictionary<string, Stream>> ExtractFilesFromMultipartMessage(IFileBinaryService fileBinaryService, Stream stream, string boundary)
         {
             var fileDictionary = new Dictionary<string, Stream>();
 
@@ -870,7 +876,7 @@ namespace CometServer.Modules
         /// <exception cref="Exception">
         /// If engineering model could not be resolved
         /// </exception>
-        private EngineeringModelSetup DetermineEngineeringModelSetup(IRequestUtils requestUtils, ICdp4TransactionManager transactionManager, IProcessor processor, string[] routeSegments)
+        private static EngineeringModelSetup DetermineEngineeringModelSetup(IRequestUtils requestUtils, ICdp4TransactionManager transactionManager, IProcessor processor, string[] routeSegments)
         {
             // override query parameters to return only extent shallow
             requestUtils.OverrideQueryParameters = new QueryParameters();
@@ -910,7 +916,7 @@ namespace CometServer.Modules
         /// <returns>
         /// The resolved <see cref="Iteration"/>.
         /// </returns>
-        private Iteration DetermineIteration(IProcessor processor, string partition, string[] routeSegments)
+        private static Iteration DetermineIteration(IProcessor processor, string partition, string[] routeSegments)
         {
             if (routeSegments.Length >= 4 && routeSegments[2] == "iteration")
             {

--- a/CometServer/Modules/10-25/ExchangeFileExportApi.cs
+++ b/CometServer/Modules/10-25/ExchangeFileExportApi.cs
@@ -198,7 +198,7 @@ namespace CometServer.Modules
 
                 var iids = jsonSerializer.Deserialize<List<Guid>>(httpRequest.Body);
 
-                var engineeringModelSetups = this.QueryExportEngineeringModelSetups(credentialsService, iids);
+                var engineeringModelSetups = QueryExportEngineeringModelSetups(credentialsService, iids);
 
                 transaction = transactionManager.SetupTransaction(ref connection, credentialsService.Credentials);
 
@@ -306,7 +306,7 @@ namespace CometServer.Modules
         /// thrown when at least one of the provided <paramref name="iids"/> does not correspond to an <see cref="EngineeringModelSetup"/>
         /// the user has access to.
         /// </exception>
-        private IEnumerable<EngineeringModelSetup> QueryExportEngineeringModelSetups (ICredentialsService credentialsService, IEnumerable<Guid> iids)
+        private static IEnumerable<EngineeringModelSetup> QueryExportEngineeringModelSetups (ICredentialsService credentialsService, IEnumerable<Guid> iids)
         {
             if (!iids.Any())
             {

--- a/CometServer/Modules/10-25/ExchangeFileImportyApi.cs
+++ b/CometServer/Modules/10-25/ExchangeFileImportyApi.cs
@@ -305,7 +305,7 @@ namespace CometServer.Modules
             var version = request.QueryDataModelVersion();
 
             // handle exchange processing
-            if (!this.InsertModelData(requestUtils, transactionManager, jsonExchangeFileReader, migrationService, revisionService, engineeringModelDao, serviceProvider, personService, personRoleService, personPermissionService, defaultPermissionProvider, participantRoleService, participantPermissionService, version, temporarysSeedFilePath, null, this.AppConfigService.AppConfig.Backtier.IsDbSeedEnabled))
+            if (!this.InsertModelData(requestUtils, transactionManager, jsonExchangeFileReader, migrationService, engineeringModelDao, serviceProvider, personService, personRoleService, personPermissionService, defaultPermissionProvider, participantRoleService, participantPermissionService, version, temporarysSeedFilePath, null, this.AppConfigService.AppConfig.Backtier.IsDbSeedEnabled))
             {
                 response.StatusCode = (int)HttpStatusCode.BadRequest;
                 await response.AsJson("invalid seed file");
@@ -371,7 +371,7 @@ namespace CometServer.Modules
         /// <returns>
         /// True if successful, false if not
         /// </returns>
-        private bool InsertModelData(IRequestUtils requestUtils, ICdp4TransactionManager transactionManager, IJsonExchangeFileReader jsonExchangeFileReader, IMigrationService migrationService, IRevisionService revisionService, IEngineeringModelDao engineeringModelDao, Services.IServiceProvider serviceProvider,  IPersonService personService, IPersonRoleService personRoleService, IPersonPermissionService personPermissionService, IDefaultPermissionProvider defaultPermissionProvider, IParticipantRoleService participantRoleService, IParticipantPermissionService participantPermissionService, Version version, string fileName, string password = null, bool seed = true)
+        private bool InsertModelData(IRequestUtils requestUtils, ICdp4TransactionManager transactionManager, IJsonExchangeFileReader jsonExchangeFileReader, IMigrationService migrationService, IEngineeringModelDao engineeringModelDao, Services.IServiceProvider serviceProvider,  IPersonService personService, IPersonRoleService personRoleService, IPersonPermissionService personPermissionService, IDefaultPermissionProvider defaultPermissionProvider, IParticipantRoleService participantRoleService, IParticipantPermissionService participantPermissionService, Version version, string fileName, string password = null, bool seed = true)
         {
             NpgsqlConnection connection = null;
             NpgsqlTransaction transaction = null;

--- a/CometServer/Modules/10-25/ExchangeFileImportyApi.cs
+++ b/CometServer/Modules/10-25/ExchangeFileImportyApi.cs
@@ -385,7 +385,7 @@ namespace CometServer.Modules
                     this.logger.LogInformation("Start clearing the current data store");
                     transaction = transactionManager.SetupTransaction(ref connection, null);
                     transactionManager.SetFullAccessState(true);
-                    this.ClearDatabaseSchemas(transaction);
+                    ClearDatabaseSchemas(transaction);
                     transaction.Commit();
 
                     // Flushes the type cache and reload the types for this connection
@@ -442,7 +442,7 @@ namespace CometServer.Modules
                 if (topContainer.GetType().Name == "SiteDirectory")
                 {
                     // make sure single iterationsetups are set to unfrozen before persitence
-                    this.FixSingleIterationSetups(items);
+                    FixSingleIterationSetups(items);
                     var siteDirectoryService =
                         serviceProvider.MapToPersitableService<SiteDirectoryService>("SiteDirectory");
 
@@ -508,7 +508,7 @@ namespace CometServer.Modules
                         this.CreateMissingParticipantPermissions(transaction, participantRoleService, participantPermissionService, defaultPermissionProvider);
 
                         // extract any referenced file data to disk if not already present
-                        this.PersistFileBinaryData(requestUtils, jsonExchangeFileReader, fileName, password);
+                        PersistFileBinaryData(requestUtils, jsonExchangeFileReader, fileName, password);
 
                         var iterationSetups = items.OfType<IterationSetup>()
                             .Where(
@@ -554,7 +554,7 @@ namespace CometServer.Modules
                         }
 
                         // extract any referenced file data to disk if not already present
-                        this.PersistFileBinaryData(requestUtils, jsonExchangeFileReader, fileName, password);
+                        PersistFileBinaryData(requestUtils, jsonExchangeFileReader, fileName, password);
                     }
                 }
 
@@ -613,7 +613,7 @@ namespace CometServer.Modules
                 this.logger.LogInformation("Start clearing the current data store");
                 transaction = transactionManager.SetupTransaction(ref connection, null);
                 transactionManager.SetFullAccessState(true);
-                this.ClearDatabaseSchemas(transaction);
+                ClearDatabaseSchemas(transaction);
                 transaction.Commit();
 
                 // Flushes the type cache and reload the types for this connection
@@ -671,7 +671,7 @@ namespace CometServer.Modules
                 if (topContainer.GetType().Name == "SiteDirectory")
                 {
                     // make sure single iterationsetups are set to unfrozen before persitence
-                    this.FixSingleIterationSetups(items);
+                    FixSingleIterationSetups(items);
 
                     var siteDirectoryService = serviceProvider.MapToPersitableService<SiteDirectoryService>("SiteDirectory");
 
@@ -745,7 +745,7 @@ namespace CometServer.Modules
                         this.CreateMissingParticipantPermissions(transaction, participantRoleService, participantPermissionService, defaultPermissionProvider);
 
                         // extract any referenced file data to disk if not already present
-                        this.PersistFileBinaryData(requestUtils, jsonExchangeFileReader, fileName, password);
+                        PersistFileBinaryData(requestUtils, jsonExchangeFileReader, fileName, password);
 
                         var iterationSetups = items.OfType<IterationSetup>()
                             .Where(
@@ -844,7 +844,7 @@ namespace CometServer.Modules
                         }
 
                         // extract any referenced file data to disk if not already present
-                        this.PersistFileBinaryData(requestUtils, jsonExchangeFileReader, fileName, password);
+                        PersistFileBinaryData(requestUtils, jsonExchangeFileReader, fileName, password);
                     }
                 }
 
@@ -890,7 +890,7 @@ namespace CometServer.Modules
         /// <param name="password">
         /// The archive password.
         /// </param>
-        private void PersistFileBinaryData(IRequestUtils requestUtils, IJsonExchangeFileReader jsonExchangeFileReader,  string fileName, string password = null)
+        private static void PersistFileBinaryData(IRequestUtils requestUtils, IJsonExchangeFileReader jsonExchangeFileReader,  string fileName, string password = null)
         {
             var fileRevisions = requestUtils.Cache.OfType<FileRevision>().ToList();
             if (!fileRevisions.Any())
@@ -913,7 +913,7 @@ namespace CometServer.Modules
         /// <param name="items">
         /// The read in items.
         /// </param>
-        private void FixSingleIterationSetups(List<Thing> items)
+        private static void FixSingleIterationSetups(List<Thing> items)
         {
             var engineeringModelSetups = items.OfType<EngineeringModelSetup>().ToList();
 
@@ -935,7 +935,7 @@ namespace CometServer.Modules
         /// <param name="transaction">
         /// The transaction.
         /// </param>
-        private void ClearDatabaseSchemas(NpgsqlTransaction transaction)
+        private static void ClearDatabaseSchemas(NpgsqlTransaction transaction)
         {
             // clear the current database data (except public and pg_catalog schemas)
             using (var cleanSchemaCommand = new NpgsqlCommand())

--- a/CometServer/Modules/10-25/ExchangeFileImportyApi.cs
+++ b/CometServer/Modules/10-25/ExchangeFileImportyApi.cs
@@ -893,7 +893,7 @@ namespace CometServer.Modules
         private static void PersistFileBinaryData(IRequestUtils requestUtils, IJsonExchangeFileReader jsonExchangeFileReader,  string fileName, string password = null)
         {
             var fileRevisions = requestUtils.Cache.OfType<FileRevision>().ToList();
-            if (!fileRevisions.Any())
+            if (fileRevisions.Count == 0)
             {
                 // nothing to do
                 return;

--- a/CometServer/Program.cs
+++ b/CometServer/Program.cs
@@ -114,11 +114,11 @@ namespace CometServer
 
                 if (!dataStoreAvailable)
                 {
-                    logger.LogCritical("The CDP4-COMET REST API has terminated - The data-store was not availble within the configured BacktierWaitTime: {0}", appConfigService.AppConfig.Midtier.BacktierWaitTime);
+                    logger.LogCritical("The CDP4-COMET REST API has terminated - The data-store was not availble within the configured BacktierWaitTime: {BacktierWaitTime}", appConfigService.AppConfig.Midtier.BacktierWaitTime);
                     return 0;
                 }
                 
-                logger.LogInformation("The data-store has become available for connections within the configured BacktierWaitTime: {0}", appConfigService.AppConfig.Midtier.BacktierWaitTime);
+                logger.LogInformation("The data-store has become available for connections within the configured BacktierWaitTime: {BacktierWaitTime}", appConfigService.AppConfig.Midtier.BacktierWaitTime);
                 
                 var migrationEngine = host.Services.GetService<IMigrationEngine>();
                 migrationEngine.MigrateAllAtStartUp();
@@ -128,7 +128,7 @@ namespace CometServer
                 var configuration = host.Services.GetService<IConfiguration>();
                 var uri = configuration.GetSection("Kestrel:Endpoints:Http:Url").Value;
 
-                logger.LogInformation("CDP4-COMET REST API Ready to accept connections at {0}", uri);
+                logger.LogInformation("CDP4-COMET REST API Ready to accept connections at {uri}", uri);
 
                 await host.RunAsync();
 

--- a/CometServer/Services/BusinessLogic/ChainOfRdlComputationService.cs
+++ b/CometServer/Services/BusinessLogic/ChainOfRdlComputationService.cs
@@ -91,7 +91,7 @@ namespace CometServer.Services
         /// </returns>
         public IEnumerable<Guid> QueryReferenceDataLibraryDependency(NpgsqlTransaction transaction, IEnumerable<EngineeringModelSetup> engineeringModelSetups)
         {
-            if (this.cachedModelReferenceDataLibraries == null || !this.cachedModelReferenceDataLibraries.Any())
+            if (this.cachedModelReferenceDataLibraries == null || this.cachedModelReferenceDataLibraries.Count == 0)
             {
                 this.Logger.LogDebug("Retrieving the ModelReferenceDataLibrary objects from the cached tables in the datastore");
 
@@ -102,7 +102,7 @@ namespace CometServer.Services
                 this.cachedModelReferenceDataLibraries.AddRange(modelReferenceDataLibraries);
             }
 
-            if (this.cachedSiteReferenceDataLibraries == null || !this.cachedSiteReferenceDataLibraries.Any())
+            if (this.cachedSiteReferenceDataLibraries == null || this.cachedSiteReferenceDataLibraries.Count == 0)
             {
                 this.Logger.LogDebug("Retrieving the SiteReferenceDataLibrary objects from the cached tables in the datastore");
 

--- a/CometServer/Services/BusinessLogic/DefaultValueArrayFactory.cs
+++ b/CometServer/Services/BusinessLogic/DefaultValueArrayFactory.cs
@@ -118,7 +118,7 @@ namespace CometServer.Services
                 this.parameterTypeAssignmentCache.Add(kvp.Key, kvp.Value);
             }
 
-            this.Logger.LogTrace("Cache initialized with {0} ParameterTypes, {1} DependentParameterTypeAssignments, {2} IndependentParameterTypeAssignments and {3} ParameterTypeComponents in {4}",
+            this.Logger.LogTrace("Cache initialized with {parameterTypeCache} ParameterTypes, {dependentParameterTypeAssignments} DependentParameterTypeAssignments, {independentParameterTypeAssignments} IndependentParameterTypeAssignments and {parameterTypeComponentCache} ParameterTypeComponents in {ElapsedMilliseconds}",
                 this.parameterTypeCache.Count,
                 dependentParameterTypeAssignments.Count,
                 independentParameterTypeAssignments.Count,

--- a/CometServer/Services/BusinessLogic/FileArchiveService.cs
+++ b/CometServer/Services/BusinessLogic/FileArchiveService.cs
@@ -235,7 +235,7 @@ namespace CometServer.Services
                     transaction,
                     authorizedContext);
 
-                if (things.Any())
+                if (things.Count != 0)
                 {
                     // Get all folders
                     var folders = things.Where(i => i.GetType() == typeof(Folder)).Cast<Folder>().ToList();
@@ -404,7 +404,7 @@ namespace CometServer.Services
             // Get folders that is of the root folder
             var subFolders = folders.Where(folder => folder.ContainingFolder == rootFolder.Iid).ToList();
 
-            if (subFolders.Any())
+            if (subFolders.Count != 0)
             {
                 foreach (var subFolder in subFolders)
                 {
@@ -457,7 +457,7 @@ namespace CometServer.Services
                                                                        && file.FileRevision.Contains(fileRevision.Iid))
                                                    .ToList();
 
-                if (tempSubFileRevisions.Any())
+                if (tempSubFileRevisions.Count != 0)
                 {
                     var subFileRevision =
                         tempSubFileRevisions.Aggregate((i1, i2) => i1.RevisionNumber > i2.RevisionNumber ? i1 : i2);

--- a/CometServer/Services/BusinessLogic/FileBinaryService.cs
+++ b/CometServer/Services/BusinessLogic/FileBinaryService.cs
@@ -115,12 +115,12 @@ namespace CometServer.Services
             var sw = new Stopwatch();
             sw.Start();
             
-            this.Logger.LogDebug("Store Binary Data with hash: {0} started", hash);
+            this.Logger.LogDebug("Store Binary Data with hash: {hash} started", hash);
 
             string filePath;
             if (this.TryGetFileStoragePath(hash, out filePath))
             {
-                this.Logger.LogDebug("The file already exists: {0}/{1}", filePath, hash);
+                this.Logger.LogDebug("The file already exists: {filePath}/{hash}", filePath, hash);
 
                 // return as file already exists
                 sw.Stop();
@@ -130,7 +130,7 @@ namespace CometServer.Services
             // create the path for the file
             var stroragePath = this.GetBinaryStoragePath(hash, true);
             filePath = Path.Combine(stroragePath, hash);
-            this.Logger.LogDebug("New File storage path: ", filePath);
+            this.Logger.LogDebug("New File storage path: {filePath}", filePath);
 
             using (var fileStream = File.Create(filePath))
             {
@@ -138,7 +138,7 @@ namespace CometServer.Services
                 data.CopyTo(fileStream);
             }
 
-            this.Logger.LogDebug("File {0} stored in {1} [ms]", filePath, sw.ElapsedMilliseconds);
+            this.Logger.LogDebug("File {filePath} stored in {ElapsedMilliseconds} [ms]", filePath, sw.ElapsedMilliseconds);
         }
 
         /// <summary>

--- a/CometServer/Services/BusinessLogic/OptionBusinessLogicService.cs
+++ b/CometServer/Services/BusinessLogic/OptionBusinessLogicService.cs
@@ -54,12 +54,12 @@ namespace CometServer.Services
         {
             if (iteration == null)
             {
-                throw new ArgumentNullException("iteration");
+                throw new ArgumentNullException(nameof(iteration));
             }
 
             if (options == null)
             {
-                throw new ArgumentNullException("options");
+                throw new ArgumentNullException(nameof(options));
             }
 
             if (iteration.Option.Count != options.Count())

--- a/CometServer/Services/BusinessLogic/ParameterValueSetFactory.cs
+++ b/CometServer/Services/BusinessLogic/ParameterValueSetFactory.cs
@@ -58,7 +58,7 @@ namespace CometServer.Services
         {
             if (valueArray.Any(value => value != "-"))
             {
-                throw new ArgumentException("The valueArray must be a default valueArray that only contains \"-\"", "valueArray");
+                throw new ArgumentException("The valueArray must be a default valueArray that only contains \"-\"", nameof(valueArray));
             }
 
             var parameterValueSet = new ParameterValueSet(Guid.NewGuid(), -1)

--- a/CometServer/Services/BusinessLogic/StateDependentParameterUpdateService.cs
+++ b/CometServer/Services/BusinessLogic/StateDependentParameterUpdateService.cs
@@ -99,7 +99,7 @@ namespace CometServer.Services
         {
             if (iteration == null)
             {
-                throw new ArgumentNullException("iteration");
+                throw new ArgumentNullException(nameof(iteration));
             }
 
             var parameters = this.ParameterService.GetShallow(transaction, partition, null, securityContext).Where(i => i is Parameter).Cast<Parameter>()

--- a/CometServer/Services/ChangeLog/ChangeLogService.cs
+++ b/CometServer/Services/ChangeLog/ChangeLogService.cs
@@ -264,16 +264,16 @@ namespace CometServer.Services.ChangeLog
 
                         if (changedThing is IOwnedThing ownedThing && !this.DataModelUtils.IsDerived(changedThing.ClassKind.ToString(), nameof(IOwnedThing.Owner)))
                         {
-                            this.AddIfNotExists(modelLogEntry.AffectedDomainIid, ownedThing.Owner);
-                            this.AddIfNotExists(newLogEntryChangelogItem.AffectedReferenceIid, ownedThing.Owner);
+                            AddIfNotExists(modelLogEntry.AffectedDomainIid, ownedThing.Owner);
+                            AddIfNotExists(newLogEntryChangelogItem.AffectedReferenceIid, ownedThing.Owner);
                         }
 
                         if (changedThing is ICategorizableThing categorizableThing)
                         {
                             foreach (var categoryIid in categorizableThing.Category)
                             {
-                                this.AddIfNotExists(modelLogEntry.AffectedItemIid, categoryIid);
-                                this.AddIfNotExists(newLogEntryChangelogItem.AffectedReferenceIid, categoryIid);
+                                AddIfNotExists(modelLogEntry.AffectedItemIid, categoryIid);
+                                AddIfNotExists(newLogEntryChangelogItem.AffectedReferenceIid, categoryIid);
                             }
                         }
                     }
@@ -380,13 +380,13 @@ namespace CometServer.Services.ChangeLog
         /// </returns>
         private LogEntryChangelogItem CreateAddOrUpdateLogEntryChangelogItem(NpgsqlTransaction transaction, string partition, Thing changedThing, ModelLogEntry modelLogEntry, CdpPostOperation operation, IReadOnlyList<Thing> changedThings)
         {
-            if (!this.IsAddLogEntryChangeLogItemAllowed(changedThing.ClassKind))
+            if (!IsAddLogEntryChangeLogItemAllowed(changedThing.ClassKind))
             {
                 return null;
             }
 
             var logEntryChangeLogItem = new LogEntryChangelogItem(Guid.NewGuid(), 0);
-            this.AddIfNotExists(modelLogEntry.AffectedItemIid, changedThing.Iid);
+            AddIfNotExists(modelLogEntry.AffectedItemIid, changedThing.Iid);
 
             if (operation.Create.SingleOrDefault(x => x.Iid == changedThing.Iid) is { })
             {
@@ -428,10 +428,10 @@ namespace CometServer.Services.ChangeLog
         /// </returns>
         private LogEntryChangelogItem CreateDeleteLogEntryChangelogItems(NpgsqlTransaction transaction, string partition, CdpPostOperation operation, ClasslessDTO deleteInfo, ModelLogEntry modelLogEntry, IReadOnlyList<Thing> changedThings)
         {
-            if (Enum.TryParse<ClassKind>(deleteInfo[nameof(Thing.ClassKind)].ToString(), out var classKind) && this.IsAddLogEntryChangeLogItemAllowed(classKind))
+            if (Enum.TryParse<ClassKind>(deleteInfo[nameof(Thing.ClassKind)].ToString(), out var classKind) && IsAddLogEntryChangeLogItemAllowed(classKind))
             {
                 var newLogEntryChangelogItem = new LogEntryChangelogItem(Guid.NewGuid(), 0);
-                this.AddIfNotExists(modelLogEntry.AffectedItemIid, (Guid) deleteInfo[nameof(Thing.Iid)]);
+                AddIfNotExists(modelLogEntry.AffectedItemIid, (Guid) deleteInfo[nameof(Thing.Iid)]);
 
                 var deletedThing = this.OperationProcessor.OperationOriginalThingCache.FirstOrDefault(x => x.Iid == (Guid) deleteInfo[nameof(Thing.Iid)]);
 
@@ -474,16 +474,16 @@ namespace CometServer.Services.ChangeLog
 
             if (createdThing is IOwnedThing ownedThing && !this.DataModelUtils.IsDerived(createdThing.ClassKind.ToString(), nameof(IOwnedThing.Owner)))
             {
-                this.AddIfNotExists(modelLogEntry.AffectedDomainIid, ownedThing.Owner);
-                this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, ownedThing.Owner);
+                AddIfNotExists(modelLogEntry.AffectedDomainIid, ownedThing.Owner);
+                AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, ownedThing.Owner);
             }
 
             if (createdThing is ICategorizableThing categorizableThing)
             {
                 foreach (var categoryIid in categorizableThing.Category)
                 {
-                    this.AddIfNotExists(modelLogEntry.AffectedItemIid, categoryIid);
-                    this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, categoryIid);
+                    AddIfNotExists(modelLogEntry.AffectedItemIid, categoryIid);
+                    AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, categoryIid);
                 }
             }
 
@@ -493,8 +493,8 @@ namespace CometServer.Services.ChangeLog
 
             if (containerThing != null)
             {
-                this.AddIfNotExists(modelLogEntry.AffectedItemIid, containerThing.Iid);
-                this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, containerThing.Iid);
+                AddIfNotExists(modelLogEntry.AffectedItemIid, containerThing.Iid);
+                AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, containerThing.Iid);
 
                 stringBuilder.AppendLine($"* {this.GetThingDescription(transaction, partition, containerThing)}");
             }
@@ -503,14 +503,14 @@ namespace CometServer.Services.ChangeLog
 
             foreach (var affectedItemId in affectedThingsData.AffectedItemIds)
             {
-                this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, affectedItemId);
-                this.AddIfNotExists(modelLogEntry.AffectedItemIid, affectedItemId);
+                AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, affectedItemId);
+                AddIfNotExists(modelLogEntry.AffectedItemIid, affectedItemId);
             }
 
             foreach (var affectedDomainId in affectedThingsData.AffectedDomainIds)
             {
-                this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, affectedDomainId);
-                this.AddIfNotExists(modelLogEntry.AffectedDomainIid, affectedDomainId);
+                AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, affectedDomainId);
+                AddIfNotExists(modelLogEntry.AffectedDomainIid, affectedDomainId);
             }
 
             foreach (var extraChangeDescription in affectedThingsData.ExtraChangeDescriptions)
@@ -558,16 +558,16 @@ namespace CometServer.Services.ChangeLog
 
             if (updatedThing is IOwnedThing ownedThing && !this.DataModelUtils.IsDerived(updatedThing.ClassKind.ToString(), nameof(IOwnedThing.Owner)))
             {
-                this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, ownedThing.Owner);
-                this.AddIfNotExists(modelLogEntry.AffectedDomainIid, ownedThing.Owner);
+                AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, ownedThing.Owner);
+                AddIfNotExists(modelLogEntry.AffectedDomainIid, ownedThing.Owner);
             }
 
             if (updatedThing is ICategorizableThing categorizableThing)
             {
                 foreach (var categoryIid in categorizableThing.Category)
                 {
-                    this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, categoryIid);
-                    this.AddIfNotExists(modelLogEntry.AffectedItemIid, categoryIid);
+                    AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, categoryIid);
+                    AddIfNotExists(modelLogEntry.AffectedItemIid, categoryIid);
                 }
             }
 
@@ -575,14 +575,14 @@ namespace CometServer.Services.ChangeLog
 
             foreach (var affectedItemId in affectedThingsData.AffectedItemIds)
             {
-                this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, affectedItemId);
-                this.AddIfNotExists(modelLogEntry.AffectedItemIid, affectedItemId);
+                AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, affectedItemId);
+                AddIfNotExists(modelLogEntry.AffectedItemIid, affectedItemId);
             }
 
             foreach (var affectedDomainId in affectedThingsData.AffectedDomainIds)
             {
-                this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, affectedDomainId);
-                this.AddIfNotExists(modelLogEntry.AffectedDomainIid, affectedDomainId);
+                AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, affectedDomainId);
+                AddIfNotExists(modelLogEntry.AffectedDomainIid, affectedDomainId);
             }
 
             var stringBuilder = new StringBuilder();
@@ -596,8 +596,8 @@ namespace CometServer.Services.ChangeLog
 
             if (containerThing != null)
             {
-                this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, containerThing.Iid);
-                this.AddIfNotExists(modelLogEntry.AffectedItemIid, containerThing.Iid);
+                AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, containerThing.Iid);
+                AddIfNotExists(modelLogEntry.AffectedItemIid, containerThing.Iid);
                 stringBuilder.AppendLine($"* {this.GetThingDescription(transaction, partition, containerThing)}");
             }
 
@@ -713,7 +713,7 @@ namespace CometServer.Services.ChangeLog
 
                 if (orgValue is IEnumerable)
                 {
-                    if (this.TryGetName(changedValueThing, out var changedThingName))
+                    if (TryGetName(changedValueThing, out var changedThingName))
                     {
                         stringBuilder.AppendLine($"  - {propertyName}: Added => {changedThingName}");
                         return;
@@ -731,7 +731,7 @@ namespace CometServer.Services.ChangeLog
                     {
                         var orgValueThing = service.GetShallow(transaction, dtoResolverHelper.Partition, new[] { (Guid) orgValue }, securityContext).FirstOrDefault();
 
-                        if (this.TryGetName(changedValueThing, out var changedThingName) && this.TryGetName(orgValueThing, out var orgThingName))
+                        if (TryGetName(changedValueThing, out var changedThingName) && TryGetName(orgValueThing, out var orgThingName))
                         {
                             stringBuilder.AppendLine($"  - {propertyName}: {orgThingName} => {changedThingName}");
                             return;
@@ -796,16 +796,16 @@ namespace CometServer.Services.ChangeLog
 
             if (deletedThing is IOwnedThing ownedThing && !this.DataModelUtils.IsDerived(deletedThing.ClassKind.ToString(), nameof(IOwnedThing.Owner)))
             {
-                this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, ownedThing.Owner);
-                this.AddIfNotExists(modelLogEntry.AffectedDomainIid, ownedThing.Owner);
+                AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, ownedThing.Owner);
+                AddIfNotExists(modelLogEntry.AffectedDomainIid, ownedThing.Owner);
             }
 
             if (deletedThing is ICategorizableThing categorizableThing)
             {
                 foreach (var categoryIid in categorizableThing.Category)
                 {
-                    this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, categoryIid);
-                    this.AddIfNotExists(modelLogEntry.AffectedItemIid, categoryIid);
+                    AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, categoryIid);
+                    AddIfNotExists(modelLogEntry.AffectedItemIid, categoryIid);
                 }
             }
 
@@ -813,14 +813,14 @@ namespace CometServer.Services.ChangeLog
 
             foreach (var affectedItemId in affectedThingsData.AffectedItemIds)
             {
-                this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, affectedItemId);
-                this.AddIfNotExists(modelLogEntry.AffectedItemIid, affectedItemId);
+                AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, affectedItemId);
+                AddIfNotExists(modelLogEntry.AffectedItemIid, affectedItemId);
             }
 
             foreach (var affectedDomainId in affectedThingsData.AffectedDomainIds)
             {
-                this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, affectedDomainId);
-                this.AddIfNotExists(modelLogEntry.AffectedDomainIid, affectedDomainId);
+                AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, affectedDomainId);
+                AddIfNotExists(modelLogEntry.AffectedDomainIid, affectedDomainId);
             }
 
             var stringBuilder = new StringBuilder();
@@ -834,8 +834,8 @@ namespace CometServer.Services.ChangeLog
 
             if (containerThing != null)
             {
-                this.AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, containerThing.Iid);
-                this.AddIfNotExists(modelLogEntry.AffectedItemIid, containerThing.Iid);
+                AddIfNotExists(logEntryChangeLogItem.AffectedReferenceIid, containerThing.Iid);
+                AddIfNotExists(modelLogEntry.AffectedItemIid, containerThing.Iid);
                 stringBuilder.AppendLine($"* {this.GetThingDescription(transaction, partition, containerThing)}");
             }
 
@@ -888,13 +888,13 @@ namespace CometServer.Services.ChangeLog
             {
                 case Parameter parameter:
                 {
-                    this.AddIfNotExists(affectedThingsData.AffectedItemIds, parameter.ParameterType);
+                        AddIfNotExists(affectedThingsData.AffectedItemIds, parameter.ParameterType);
 
                     if (this.ParameterTypeService.GetShallow(transaction, siteDirectoryPartition, new[] { parameter.ParameterType }, securityContext).Single() is ParameterType parameterType)
                     {
                         foreach (var category in parameterType.Category)
                         {
-                            this.AddIfNotExists(affectedThingsData.AffectedItemIds, category);
+                                AddIfNotExists(affectedThingsData.AffectedItemIds, category);
                         }
                     }
 
@@ -905,7 +905,7 @@ namespace CometServer.Services.ChangeLog
                         {
                             foreach (var parameterSubscription in parameter.ParameterSubscription)
                             {
-                                this.AddIfNotExists(affectedThingsData.AffectedItemIds, parameterSubscription);
+                                    AddIfNotExists(affectedThingsData.AffectedItemIds, parameterSubscription);
                             }
                         }
                     }
@@ -918,8 +918,8 @@ namespace CometServer.Services.ChangeLog
 
                     if (getContainerReferences)
                     {
-                        this.AddIfNotExists(affectedThingsData.AffectedDomainIds, parameter.Owner);
-                        this.AddIfNotExists(affectedThingsData.AffectedItemIds, parameter.Iid);
+                            AddIfNotExists(affectedThingsData.AffectedDomainIds, parameter.Owner);
+                            AddIfNotExists(affectedThingsData.AffectedItemIds, parameter.Iid);
                     }
 
                     break;
@@ -938,11 +938,11 @@ namespace CometServer.Services.ChangeLog
 
                         foreach (var category in elementUsage.Category)
                         {
-                            this.AddIfNotExists(affectedThingsData.AffectedItemIds, category);
+                                AddIfNotExists(affectedThingsData.AffectedItemIds, category);
                         }
 
-                        this.AddIfNotExists(affectedThingsData.AffectedDomainIds, elementUsage.Owner);
-                        this.AddIfNotExists(affectedThingsData.AffectedItemIds, elementUsage.Iid);
+                            AddIfNotExists(affectedThingsData.AffectedDomainIds, elementUsage.Owner);
+                            AddIfNotExists(affectedThingsData.AffectedItemIds, elementUsage.Iid);
                     }
 
                     break;
@@ -955,11 +955,11 @@ namespace CometServer.Services.ChangeLog
 
                         foreach (var category in elementDefinition.Category)
                         {
-                            this.AddIfNotExists(affectedThingsData.AffectedItemIds, category);
+                                AddIfNotExists(affectedThingsData.AffectedItemIds, category);
                         }
 
-                        this.AddIfNotExists(affectedThingsData.AffectedDomainIds, elementDefinition.Owner);
-                        this.AddIfNotExists(affectedThingsData.AffectedItemIds, elementDefinition.Iid);
+                            AddIfNotExists(affectedThingsData.AffectedDomainIds, elementDefinition.Owner);
+                            AddIfNotExists(affectedThingsData.AffectedItemIds, elementDefinition.Iid);
                     }
 
                     break;
@@ -974,7 +974,7 @@ namespace CometServer.Services.ChangeLog
                         {
                             foreach (var parameterSubscription in parameterOverride.ParameterSubscription)
                             {
-                                this.AddIfNotExists(affectedThingsData.AffectedItemIds, parameterSubscription);
+                                    AddIfNotExists(affectedThingsData.AffectedItemIds, parameterSubscription);
                             }
                         }
                     }
@@ -997,8 +997,8 @@ namespace CometServer.Services.ChangeLog
 
                     if (getContainerReferences)
                     {
-                        this.AddIfNotExists(affectedThingsData.AffectedDomainIds, parameterOverride.Owner);
-                        this.AddIfNotExists(affectedThingsData.AffectedItemIds, parameterOverride.Iid);
+                            AddIfNotExists(affectedThingsData.AffectedDomainIds, parameterOverride.Owner);
+                            AddIfNotExists(affectedThingsData.AffectedItemIds, parameterOverride.Iid);
                     }
 
                     break;
@@ -1051,8 +1051,8 @@ namespace CometServer.Services.ChangeLog
 
                     if (getContainerReferences)
                     {
-                        this.AddIfNotExists(affectedThingsData.AffectedDomainIds, parameterSubscription.Owner);
-                        this.AddIfNotExists(affectedThingsData.AffectedItemIds, parameterSubscription.Iid);
+                            AddIfNotExists(affectedThingsData.AffectedDomainIds, parameterSubscription.Owner);
+                            AddIfNotExists(affectedThingsData.AffectedItemIds, parameterSubscription.Iid);
                     }
 
                     break;
@@ -1127,7 +1127,7 @@ namespace CometServer.Services.ChangeLog
                     return null;
                 }
 
-                var addContainer = this.GetContainerFromPossibleContainers(updatedThing, possibleContainers, containerPropertyName);
+                var addContainer = GetContainerFromPossibleContainers(updatedThing, possibleContainers, containerPropertyName);
 
                 return addContainer;
             }
@@ -1180,7 +1180,7 @@ namespace CometServer.Services.ChangeLog
                     }
                 }
 
-                var addContainer = this.GetContainerFromPossibleContainers(deletedThing, possibleContainers, containerPropertyName);
+                var addContainer = GetContainerFromPossibleContainers(deletedThing, possibleContainers, containerPropertyName);
 
                 return addContainer;
             }
@@ -1207,7 +1207,7 @@ namespace CometServer.Services.ChangeLog
         /// <returns>
         /// <paramref name="updatedThing"/>'s container <see cref="Thing"/> if found, otherwise null
         /// </returns>
-        private Thing GetContainerFromPossibleContainers(Thing updatedThing, List<Thing> possibleContainers, string containerPropertyName)
+        private static Thing GetContainerFromPossibleContainers(Thing updatedThing, List<Thing> possibleContainers, string containerPropertyName)
         {
             var propInfo =
                 possibleContainers
@@ -1284,7 +1284,7 @@ namespace CometServer.Services.ChangeLog
                 }
             }
 
-            return this.GetContainerFromPossibleContainers(thing, possibleContainers, containerPropertyName);
+            return GetContainerFromPossibleContainers(thing, possibleContainers, containerPropertyName);
         }
 
         /// <summary>
@@ -1310,12 +1310,12 @@ namespace CometServer.Services.ChangeLog
 
             var description = thing.ClassKind.ToString();
 
-            if (this.TryGetName(thing, out var namedThingName))
+            if (TryGetName(thing, out var namedThingName))
             {
                 description = $"{description} => {namedThingName}";
             }
 
-            if (this.TryGetShortName(thing, out var shortNamedThingShortName))
+            if (TryGetShortName(thing, out var shortNamedThingShortName))
             {
                 description = $"{description} ({shortNamedThingShortName})";
             }
@@ -1426,7 +1426,7 @@ namespace CometServer.Services.ChangeLog
         /// </summary>
         /// <param name="guids">The <see cref="ICollection{T}"/> of type <see cref="Guid"/></param>
         /// <param name="newGuid">The <see cref="Guid"/></param>
-        private void AddIfNotExists(ICollection<Guid> guids, Guid newGuid)
+        private static void AddIfNotExists(ICollection<Guid> guids, Guid newGuid)
         {
             if (!guids.Contains(newGuid))
             {
@@ -1502,7 +1502,7 @@ namespace CometServer.Services.ChangeLog
         /// <returns>
         /// True if creation is allowed, otherwise false.
         /// </returns>
-        private bool IsAddLogEntryChangeLogItemAllowed(ClassKind classKind)
+        private static bool IsAddLogEntryChangeLogItemAllowed(ClassKind classKind)
         {
             var relevantClassKinds = new List<ClassKind>
             {
@@ -1525,7 +1525,7 @@ namespace CometServer.Services.ChangeLog
         /// <param name="thing">The <see cref="Thing"/></param>
         /// <param name="name">The <see cref="INamedThing.Name"/></param>
         /// <returns>True, if the <see cref="Thing"/> has a readable <see cref="INamedThing.Name"/> property, otherwise false</returns>
-        private bool TryGetName(Thing thing, out string name)
+        private static bool TryGetName(Thing thing, out string name)
         {
             name = null;
 
@@ -1551,7 +1551,7 @@ namespace CometServer.Services.ChangeLog
         /// <param name="thing">The <see cref="Thing"/></param>
         /// <param name="shortName">The <see cref="IShortNamedThing.ShortName"/></param>
         /// <returns>True, if the <see cref="Thing"/> has a readable <see cref="IShortNamedThing.ShortName"/> property, otherwise false</returns>
-        private bool TryGetShortName(Thing thing, out string shortName)
+        private static bool TryGetShortName(Thing thing, out string shortName)
         {
             shortName = null;
 

--- a/CometServer/Services/ChangeLog/ChangeLogService.cs
+++ b/CometServer/Services/ChangeLog/ChangeLogService.cs
@@ -281,7 +281,7 @@ namespace CometServer.Services.ChangeLog
                     foreach (var deleteInfo in operation.Delete)
                     {
                         var newLogEntryChangelogItem =
-                            this.CreateDeleteLogEntryChangelogItems(transaction, partition, operation, deleteInfo, modelLogEntry, changedThings);
+                            this.CreateDeleteLogEntryChangelogItems(transaction, partition, deleteInfo, modelLogEntry, changedThings);
 
                         if (newLogEntryChangelogItem != null)
                         {
@@ -426,7 +426,7 @@ namespace CometServer.Services.ChangeLog
         /// <returns>
         /// The created <see cref="CDP4Common.CommonData.LogEntryChangelogItem"/>s.
         /// </returns>
-        private LogEntryChangelogItem CreateDeleteLogEntryChangelogItems(NpgsqlTransaction transaction, string partition, CdpPostOperation operation, ClasslessDTO deleteInfo, ModelLogEntry modelLogEntry, IReadOnlyList<Thing> changedThings)
+        private LogEntryChangelogItem CreateDeleteLogEntryChangelogItems(NpgsqlTransaction transaction, string partition, ClasslessDTO deleteInfo, ModelLogEntry modelLogEntry, IReadOnlyList<Thing> changedThings)
         {
             if (Enum.TryParse<ClassKind>(deleteInfo[nameof(Thing.ClassKind)].ToString(), out var classKind) && IsAddLogEntryChangeLogItemAllowed(classKind))
             {

--- a/CometServer/Services/ChangeLog/ChangeLogService.cs
+++ b/CometServer/Services/ChangeLog/ChangeLogService.cs
@@ -289,7 +289,7 @@ namespace CometServer.Services.ChangeLog
                         }
                     }
 
-                    if (newLogEntryChangelogItems.Any())
+                    if (newLogEntryChangelogItems.Count != 0)
                     {
                         modelLogEntry.LogEntryChangelogItem.AddRange(newLogEntryChangelogItems.Select(x => x.Iid));
 
@@ -1122,7 +1122,7 @@ namespace CometServer.Services.ChangeLog
 
                 var possibleContainers = service.GetShallow(transaction, containerPartition, null, securityContext).ToList();
 
-                if (!possibleContainers.Any())
+                if (possibleContainers.Count == 0)
                 {
                     return null;
                 }
@@ -1165,7 +1165,7 @@ namespace CometServer.Services.ChangeLog
                 var possibleContainers =
                     this.OperationProcessor.OperationOriginalThingCache.Where(x => x.ClassKind.ToString() == containerClassType).ToList();
 
-                if (!possibleContainers.Any())
+                if (possibleContainers.Count == 0)
                 {
                     foreach (var possibleContainerThing in changedThings)
                     {
@@ -1273,7 +1273,7 @@ namespace CometServer.Services.ChangeLog
 
             var possibleContainers = containerThings.Where(x => x.ClassKind.ToString() == containerClassType).ToList();
 
-            if (!possibleContainers.Any())
+            if (possibleContainers.Count == 0)
             {
                 foreach (var possibleContainerThing in containerThings)
                 {
@@ -1461,7 +1461,7 @@ namespace CometServer.Services.ChangeLog
                     .Cast<PossibleFiniteState>()
                     .ToList(); 
 
-            if (!possibleFiniteStates.Any())
+            if (possibleFiniteStates.Count == 0)
             {
                 return;
             }

--- a/CometServer/Services/CherryPick/ContainmentService.cs
+++ b/CometServer/Services/CherryPick/ContainmentService.cs
@@ -61,7 +61,7 @@ namespace CometServer.Services.CherryPick
 
                 allRetrievedThings.AddRange(containedThings);
                 containers = containedThings;
-            } while (containedThings.Any() && queryDeep);
+            } while (containedThings.Count != 0 && queryDeep);
 
             return allRetrievedThings;
         }

--- a/CometServer/Services/Copy/CopySourceService.cs
+++ b/CometServer/Services/Copy/CopySourceService.cs
@@ -85,7 +85,7 @@ namespace CometServer.Services
             // also get all referenced element-definition as they dont exist in target iteration
             if (copyinfo.Source.IterationId.Value != copyinfo.Target.IterationId.Value)
             {
-                source.AddRange(this.GetElementDefinitionTreeFromRootDefinition(transaction, partition, securityContext, source, readservice, source.Select(x => x.Iid).ToList()));
+                source.AddRange(GetElementDefinitionTreeFromRootDefinition(transaction, partition, securityContext, source, readservice, source.Select(x => x.Iid).ToList()));
             }
 
             // revert context to current
@@ -120,7 +120,7 @@ namespace CometServer.Services
         /// <param name="readservice">The element-definition read service</param>
         /// <param name="allSourcesId">A list containing the identifier of all things to copy</param>
         /// <returns>A list containing additional <see cref="Thing"/> to copy</returns>guid
-        private IReadOnlyList<Thing> GetElementDefinitionTreeFromRootDefinition(NpgsqlTransaction transaction, string partition, ISecurityContext securityContext, IReadOnlyList<Thing> source, IReadService readservice, IReadOnlyList<Guid> allSourcesId)
+        private static IReadOnlyList<Thing> GetElementDefinitionTreeFromRootDefinition(NpgsqlTransaction transaction, string partition, ISecurityContext securityContext, IReadOnlyList<Thing> source, IReadService readservice, IReadOnlyList<Guid> allSourcesId)
         {
             var additionalSources = new List<Thing>();
             var usages = source.OfType<ElementUsage>().ToArray();
@@ -128,7 +128,7 @@ namespace CometServer.Services
             {
                 var getResults = readservice.GetDeep(transaction, partition, usages.Select(x => x.ElementDefinition).Distinct().Where(x => !allSourcesId.Contains(x)).ToArray(), securityContext).ToList();
                 additionalSources.AddRange(getResults);
-                additionalSources.AddRange(this.GetElementDefinitionTreeFromRootDefinition(transaction, partition, securityContext, getResults, readservice, allSourcesId.Union(getResults.Select(x => x.Iid)).ToList()));
+                additionalSources.AddRange(GetElementDefinitionTreeFromRootDefinition(transaction, partition, securityContext, getResults, readservice, allSourcesId.Union(getResults.Select(x => x.Iid)).ToList()));
             }
 
             return additionalSources;

--- a/CometServer/Services/DataStore/DataStoreConnectionChecker.cs
+++ b/CometServer/Services/DataStore/DataStoreConnectionChecker.cs
@@ -74,7 +74,7 @@ namespace CometServer.Services.DataStore
                 }
                 catch (Exception)
                 {
-                    this.Logger.LogInformation("Waiting for the data store at {0}:{1} to become availble in {2} [s]",
+                    this.Logger.LogInformation("Waiting for the data store at {HostName}:{Port} to become availble in {remainingSeconds} [s]",
                         this.AppConfigService.AppConfig.Backtier.HostName,
                         this.AppConfigService.AppConfig.Backtier.Port,
                         remainingSeconds);

--- a/CometServer/Services/JsonExchangeFile/JsonExchangeFileReader.cs
+++ b/CometServer/Services/JsonExchangeFile/JsonExchangeFileReader.cs
@@ -90,7 +90,7 @@ namespace CometServer.Services
         /// </returns>
         public IEnumerable<CDP4Common.DTO.Thing> ReadSiteDirectoryFromfile(Version version, string filePath, string password)
         {
-            var memoryStream = this.ReadFileToMemory(filePath);
+            var memoryStream = ReadFileToMemory(filePath);
             return this.ReadSiteDirectoryDataFromStream(version, memoryStream, password);
         }
 
@@ -114,7 +114,7 @@ namespace CometServer.Services
         /// </returns>
         public IEnumerable<CDP4Common.DTO.Thing> ReadEngineeringModelFromfile(Version version,  string filePath,  string password, EngineeringModelSetup engineeringModelSetup)
         {
-            var memoryStream = this.ReadFileToMemory(filePath);
+            var memoryStream = ReadFileToMemory(filePath);
             return this.ReadEngineeringModelDataFromStream(version, memoryStream, password, engineeringModelSetup);
         }
 
@@ -138,7 +138,7 @@ namespace CometServer.Services
         /// </returns>
         public IEnumerable<CDP4Common.DTO.Thing> ReadModelIterationFromFile(Version version, string filePath, string password, IterationSetup iterationSetup)
         {
-            var memoryStream = this.ReadFileToMemory(filePath);
+            var memoryStream = ReadFileToMemory(filePath);
             return this.ReadIterationModelDataFromStream(version, memoryStream, password, iterationSetup);
         }
         
@@ -156,7 +156,7 @@ namespace CometServer.Services
         /// </param>
         public void StoreFileBinary(string filePath, string password, string fileHash)
         {
-            var memoryStream = this.ReadFileToMemory(filePath);
+            var memoryStream = ReadFileToMemory(filePath);
             this.ExtractFileBinaryByHash(memoryStream, password, fileHash);
         }
 
@@ -169,7 +169,7 @@ namespace CometServer.Services
         /// <returns>
         /// The <see cref="MemoryStream"/>.
         /// </returns>
-        private MemoryStream ReadFileToMemory(string filePath)
+        private static MemoryStream ReadFileToMemory(string filePath)
         {
             var memoryStream = new MemoryStream();
 
@@ -496,7 +496,7 @@ namespace CometServer.Services
         /// </returns>
         public IList<MigrationPasswordCredentials> ReadMigrationJsonFromFile(string filePath, string password)
         {
-            var memoryStream = this.ReadFileToMemory(filePath);
+            var memoryStream = ReadFileToMemory(filePath);
             return this.ReadMigrationJsonFromStream(memoryStream, password);
         }
 

--- a/CometServer/Services/JsonExchangeFile/JsonExchangeFileReader.cs
+++ b/CometServer/Services/JsonExchangeFile/JsonExchangeFileReader.cs
@@ -208,7 +208,7 @@ namespace CometServer.Services
                     var siteDirectoryZipEntry = zip.Entries.SingleOrDefault(x => x.FileName.EndsWith("SiteDirectory.json"));
 
                     var returnedSiteDirectory = this.ReadInfoFromArchiveEntry(version, siteDirectoryZipEntry, password);
-                    this.Logger.LogInformation("{0} Site Directory item(s) encountered", returnedSiteDirectory.Count);
+                    this.Logger.LogInformation("{count} Site Directory item(s) encountered", returnedSiteDirectory.Count);
 
                     var returned = new List<CDP4Common.DTO.Thing>(returnedSiteDirectory);
                     var processedRdls = new List<string>();
@@ -230,7 +230,7 @@ namespace CometServer.Services
                         var modelRdlZipEntry = zip.Entries.SingleOrDefault(x => x.FileName.EndsWith(modelRdlFilePath));
                         var modelRdlItems = this.ReadInfoFromArchiveEntry(version, modelRdlZipEntry, password);
 
-                        this.Logger.LogInformation("{0} Model Reference Data Library item(s) encountered", returnedSiteDirectory.Count);
+                        this.Logger.LogInformation("{Count} Model Reference Data Library item(s) encountered", returnedSiteDirectory.Count);
                         returned.AddRange(modelRdlItems);
 
                         // load the reference data libraries as per the containment chain
@@ -238,7 +238,7 @@ namespace CometServer.Services
 
                         while (requiredRdl != null)
                         {
-                            this.Logger.LogInformation("Required Reference Data Library encountered: {0}", requiredRdl);
+                            this.Logger.LogInformation("Required Reference Data Library encountered: {requiredRdl}", requiredRdl);
 
                             var siteRdlDto =
                                 (SiteReferenceDataLibrary)
@@ -254,7 +254,7 @@ namespace CometServer.Services
 
                                 var siteRdlItems = this.ReadInfoFromArchiveEntry(version, siteRdlZipEntry, password);
 
-                                this.Logger.LogInformation("{0} Site Reference Data Library item(s) encountered", siteRdlItems.Count);
+                                this.Logger.LogInformation("{Count} Site Reference Data Library item(s) encountered", siteRdlItems.Count);
                                 returned.AddRange(siteRdlItems);
 
                                 // register this processedRdl
@@ -266,7 +266,7 @@ namespace CometServer.Services
                         }
                     }
 
-                    this.Logger.LogInformation("{0} Site Directory items encountered", returned.Count);
+                    this.Logger.LogInformation("{Count} Site Directory items encountered", returned.Count);
                     return returned;
                 }
             }
@@ -312,13 +312,13 @@ namespace CometServer.Services
                     var engineeringModelZipEntry = zip.Entries.SingleOrDefault(x => x.FileName.EndsWith(engineeringModelFilePath));
                     var engineeringModelItems = this.ReadInfoFromArchiveEntry(version, engineeringModelZipEntry, password);
 
-                    this.Logger.LogInformation("{0} Engineering Model item(s) encountered", engineeringModelItems.Count);
+                    this.Logger.LogInformation("{Count} Engineering Model item(s) encountered", engineeringModelItems.Count);
                     return engineeringModelItems;
                 }
             }
             catch (Exception ex)
             {
-                var msg = string.Format("{0}: {1}", "Failed to load file. Error", ex.Message);
+                var msg = $"Failed to load file. Error: {ex.Message}";
                 this.Logger.LogError(msg);
 
                 throw new FileLoadException(msg);
@@ -358,13 +358,13 @@ namespace CometServer.Services
                     var iterationZipEntry = zip.Entries.SingleOrDefault(x => x.FileName.EndsWith(iterationFilePath));
                     var iterationItems = this.ReadInfoFromArchiveEntry(version, iterationZipEntry, password);
 
-                    this.Logger.LogInformation("{0} Iteration item(s) encountered", iterationItems.Count);
+                    this.Logger.LogInformation("{Count} Iteration item(s) encountered", iterationItems.Count);
                     return iterationItems;
                 }
             }
             catch (Exception ex)
             {
-                var msg = string.Format("{0}: {1}", "Failed to load file. Error", ex.Message);
+                var msg = $"Failed to load file. Error: {ex.Message}";
                 this.Logger.LogError(msg);
 
                 throw new FileLoadException(msg);
@@ -398,7 +398,7 @@ namespace CometServer.Services
 
                 using (var stream = this.ReadStreamFromArchive(fileZipEntry, archivePassword))
                 {
-                    this.Logger.LogInformation("Store file binary with hash {0}", hash);
+                    this.Logger.LogInformation("Store file binary with hash {hash}", hash);
                     this.FileBinaryService.StoreBinaryData(hash, stream);
                 }
             }
@@ -433,7 +433,7 @@ namespace CometServer.Services
             }
 
             watch.Stop();
-            this.Logger.LogInformation("JSON Deserializer completed in {0} ", watch.Elapsed);
+            this.Logger.LogInformation("JSON Deserializer completed in {ElapsedMilliseconds} [ms]", watch.ElapsedMilliseconds);
             return returned.ToList();
         }
 
@@ -470,14 +470,14 @@ namespace CometServer.Services
             }
             catch (Exception ex)
             {
-                var msg = $"{"Failed to open file. Error"}: {ex.Message}";
+                var msg = $"Failed to open file. Error: {ex.Message}";
                 this.Logger.LogError(msg);
 
                 throw new FileLoadException(msg);
             }
 
             watch.Stop();
-            this.Logger.LogInformation("JSONFile GET completed in {0} ", watch.Elapsed);
+            this.Logger.LogInformation("JSONFile GET completed in {ElapsedMilliseconds} [ms]", watch.ElapsedMilliseconds);
 
             return new MemoryStream(extractStream.ToArray());
         }

--- a/CometServer/Services/JsonExchangeFile/JsonExchangeFileWriter.cs
+++ b/CometServer/Services/JsonExchangeFile/JsonExchangeFileWriter.cs
@@ -352,7 +352,7 @@ namespace CometServer.Services
 
             foreach (var engineeringModelSetup in engineeringModelSetupsToBeRemoved)
             {
-                this.PruneThingAndContainedThingsFromThingCache(ref siteDirectoryCache, engineeringModelSetup);
+                PruneThingAndContainedThingsFromThingCache(ref siteDirectoryCache, engineeringModelSetup);
             }
 
             foreach (var engineeringModelSetup in engineeringModelSetupsToBeRemoved)
@@ -384,7 +384,7 @@ namespace CometServer.Services
 
                 if (!keepPerson)
                 {
-                    this.PruneThingAndContainedThingsFromThingCache(ref siteDirectoryCache, person);
+                    PruneThingAndContainedThingsFromThingCache(ref siteDirectoryCache, person);
                     siteDirectory.Person.Remove(person.Iid);
                 }
             }
@@ -413,7 +413,7 @@ namespace CometServer.Services
 
                 if (!keepPersonRole)
                 {
-                    this.PruneThingAndContainedThingsFromThingCache(ref siteDirectoryCache, personRole);
+                    PruneThingAndContainedThingsFromThingCache(ref siteDirectoryCache, personRole);
                     siteDirectory.PersonRole.Remove(personRole.Iid);
                 }
             }
@@ -442,7 +442,7 @@ namespace CometServer.Services
 
                 if (!keepParticipantRole)
                 {
-                    this.PruneThingAndContainedThingsFromThingCache(ref siteDirectoryCache, participantRole);
+                    PruneThingAndContainedThingsFromThingCache(ref siteDirectoryCache, participantRole);
                     siteDirectory.ParticipantRole.Remove(participantRole.Iid);
                 }
             }
@@ -485,7 +485,7 @@ namespace CometServer.Services
 
                 if (!keepDomainOfExpertise)
                 {
-                    this.PruneThingAndContainedThingsFromThingCache(ref siteDirectoryCache, domainOfExpertise);
+                    PruneThingAndContainedThingsFromThingCache(ref siteDirectoryCache, domainOfExpertise);
                     siteDirectory.Domain.Remove(domainOfExpertise.Iid);
                 }
             }
@@ -524,7 +524,7 @@ namespace CometServer.Services
                 var modelrdl = (ReferenceDataLibrary) modelReferenceDataLibrary;
                 result.Add(modelrdl);
 
-                var rdls = this.QueryRequiredRdl(modelrdl, siteDirectoryCache);
+                var rdls = QueryRequiredRdl(modelrdl, siteDirectoryCache);
 
                 foreach (var rdl in rdls)
                 {
@@ -535,7 +535,7 @@ namespace CometServer.Services
             return result;
         }
 
-        private IEnumerable<ReferenceDataLibrary> QueryRequiredRdl(ReferenceDataLibrary referenceDataLibrary, Dictionary<Guid, Thing> siteDirectoryCache)
+        private static IEnumerable<ReferenceDataLibrary> QueryRequiredRdl(ReferenceDataLibrary referenceDataLibrary, Dictionary<Guid, Thing> siteDirectoryCache)
         {
             if (referenceDataLibrary.RequiredRdl.HasValue)
             {
@@ -544,7 +544,7 @@ namespace CometServer.Services
                     var rdl = (ReferenceDataLibrary) requiredRdl;
                     yield return rdl;
 
-                    var requiredRdls =  this.QueryRequiredRdl(rdl, siteDirectoryCache);
+                    var requiredRdls = QueryRequiredRdl(rdl, siteDirectoryCache);
 
                     foreach (var dataLibrary in requiredRdls)
                     {
@@ -568,7 +568,7 @@ namespace CometServer.Services
         /// Prunes
         /// </summary>
         /// <param name="thing"></param>
-        private void PruneThingAndContainedThingsFromThingCache(ref Dictionary<Guid, Thing> dictionary, Thing thing)
+        private static void PruneThingAndContainedThingsFromThingCache(ref Dictionary<Guid, Thing> dictionary, Thing thing)
         {
             foreach (var thingContainerList in thing.ContainerLists)
             {
@@ -576,7 +576,7 @@ namespace CometServer.Services
                 {
                     if (dictionary.TryGetValue(containedThingIdentifier, out var containedThing))
                     {
-                        this.PruneThingAndContainedThingsFromThingCache(ref dictionary, containedThing);
+                        PruneThingAndContainedThingsFromThingCache(ref dictionary, containedThing);
                     }
                 } 
             }

--- a/CometServer/Services/JsonExchangeFile/JsonExchangeFileWriter.cs
+++ b/CometServer/Services/JsonExchangeFile/JsonExchangeFileWriter.cs
@@ -33,6 +33,7 @@ namespace CometServer.Services
     using CDP4Common.DTO;
 
     using CometServer.Authorization;
+    using CometServer.Exceptions;
     using CometServer.Services.Authorization;
     using CometServer.Services.Protocol;
 
@@ -239,7 +240,12 @@ namespace CometServer.Services
         private ExchangeFileHeader CreateExchangeFileHeader(Dictionary<Guid, Thing> siteDirectoryCache)
         {
             var person = siteDirectoryCache.Values.OfType<Person>().SingleOrDefault(x => x.ShortName == this.CredentialsService.Credentials.Person.UserName);
-            
+
+            if (person == null)
+            {
+                throw new ThingNotFoundException($"The Person object represented by {this.CredentialsService.Credentials.Person.UserName} could not be found");
+            }
+
             EmailAddress email = null;
 
             if (person.DefaultEmailAddress != null)

--- a/CometServer/Services/JsonExchangeFile/JsonExchangeFileWriter.cs
+++ b/CometServer/Services/JsonExchangeFile/JsonExchangeFileWriter.cs
@@ -182,7 +182,7 @@ namespace CometServer.Services
                 var engineeringModelPartition = this.RequestUtils.GetEngineeringModelPartitionString(engineeringModelSetup.EngineeringModelIid);
                 var engineeringModelThings = this.EngineeringModelService.GetDeep(transaction, engineeringModelPartition, new List<Guid> { engineeringModelSetup.EngineeringModelIid }, new RequestSecurityContext { ContainerReadAllowed = true }).ToList();
 
-                if (engineeringModelSetup.OrganizationalParticipant.Any())
+                if (engineeringModelSetup.OrganizationalParticipant.Count != 0)
                 {
                     this.ObfuscationService.ObfuscateResponse(engineeringModelThings, this.CredentialsService.Credentials);
                 }
@@ -201,7 +201,7 @@ namespace CometServer.Services
 
                      var iterationThings = this.IterationService.GetDeep(transaction, engineeringModelPartition, new List<Guid> { iterationSetup.IterationIid }, new RequestSecurityContext { ContainerReadAllowed = true }).ToList();
 
-                     if (engineeringModelSetup.OrganizationalParticipant.Any())
+                     if (engineeringModelSetup.OrganizationalParticipant.Count != 0)
                      {
                          this.ObfuscationService.ObfuscateResponse(iterationThings, this.CredentialsService.Credentials);
                      }

--- a/CometServer/Services/Operations/ModelCreatorManager.cs
+++ b/CometServer/Services/Operations/ModelCreatorManager.cs
@@ -213,18 +213,18 @@ namespace CometServer.Services.Operations
             this.DisableUserTrigger(transaction);
 
             // copy all data from the source to the target partition
-            this.Logger.LogDebug("Copy EngineeringModel data from {0} to {1}", sourcePartition, targetPartition);
+            this.Logger.LogDebug("Copy EngineeringModel data from {sourcePartition} to {targetPartition}", sourcePartition, targetPartition);
             this.EngineeringModelService.CopyEngineeringModel(transaction, sourcePartition, targetPartition);
-            this.Logger.LogDebug("Copy Iteration data from {0} to {1}", sourceIterationPartition, targetIterationPartition);
+            this.Logger.LogDebug("Copy Iteration data from {sourceIterationPartition} to {targetIterationPartition}", sourceIterationPartition, targetIterationPartition);
             this.IterationService.CopyIteration(transaction, sourceIterationPartition, targetIterationPartition);
 
             // wipe the organizational participations
             this.IterationService.DeleteAllrganizationalParticipantThings(transaction, targetIterationPartition);
 
             // change id on Thing table for all other things
-            this.Logger.LogDebug("Modify Identifiers of EngineeringModel {0} data", targetPartition);
+            this.Logger.LogDebug("Modify Identifiers of EngineeringModel {targetPartition} data", targetPartition);
             this.EngineeringModelService.ModifyIdentifier(transaction, targetPartition);
-            this.Logger.LogDebug("Modify Identifiers of Iteration {0} data", targetIterationPartition);
+            this.Logger.LogDebug("Modify Identifiers of Iteration {targetIterationPartition} data", targetIterationPartition);
             this.EngineeringModelService.ModifyIdentifier(transaction, targetIterationPartition);
 
             // update iid for engineering-model and iteration(s)
@@ -238,7 +238,7 @@ namespace CometServer.Services.Operations
             newEngineeringModel.Iid = newModelSetup.EngineeringModelIid;
             newEngineeringModel.EngineeringModelSetup = newModelSetup.Iid;
 
-            this.Logger.LogDebug("Modify Identifier of new EngineeringModel {0} to {1}", oldIid, newModelSetup.EngineeringModelIid);
+            this.Logger.LogDebug("Modify Identifier of new EngineeringModel {oldIid} to {EngineeringModelIid}", oldIid, newModelSetup.EngineeringModelIid);
             this.EngineeringModelService.ModifyIdentifier(transaction, targetPartition, newEngineeringModel, oldIid);
 
             if (!this.EngineeringModelService.UpdateConcept(transaction, targetPartition, newEngineeringModel, null))
@@ -251,7 +251,7 @@ namespace CometServer.Services.Operations
             modelThings.AddRange(this.IterationService.GetDeep(transaction, targetPartition, null, securityContext));
 
             var sw = Stopwatch.StartNew();
-            this.Logger.LogDebug("start modify {0} references of things contained in the new engineering-model-setup (rdl included)", modelThings.Count);
+            this.Logger.LogDebug("start modify {Count} references of things contained in the new engineering-model-setup (rdl included)", modelThings.Count);
             foreach (var modelThing in modelThings)
             {
                 var model = modelThing as EngineeringModel;
@@ -304,7 +304,7 @@ namespace CometServer.Services.Operations
                 }
             }
 
-            this.Logger.LogDebug("modified {modelThings.Count} references of things contained in the new engineering-model-setup in {sw} [ms]", modelThings.Count, sw.ElapsedMilliseconds);
+            this.Logger.LogDebug("modified {Count} references of things contained in the new engineering-model-setup in {Count} [ms]", modelThings.Count, sw.ElapsedMilliseconds);
 
             // IMPORTANT: re-enable user trigger once the current transaction is commited commited
         }

--- a/CometServer/Services/Operations/OperationProcessor.cs
+++ b/CometServer/Services/Operations/OperationProcessor.cs
@@ -889,7 +889,7 @@ namespace CometServer.Services.Operations
                 // check if the delete info has any properties set other than Iid, revision and classkind properties
                 var operationProperties = deleteInfo.Where(x => !this.baseProperties.Contains(x.Key)).ToList();
 
-                if (!operationProperties.Any())
+                if (operationProperties.Count == 0)
                 {
                     var dtoInfo = deleteInfo.GetInfoPlaceholder();
                     this.ExecuteDeleteOperation(dtoInfo, transaction, metaInfo);
@@ -983,7 +983,7 @@ namespace CometServer.Services.Operations
             // re-order create
             ReorderCreateOrder(operation);
 
-            if (operation.Create.Any())
+            if (operation.Create.Count != 0)
             {
                 var operationInfoPlaceholders = operation.Create.Select(x => x.GetInfoPlaceholder());
                 var securityContext = new RequestSecurityContext { ContainerReadAllowed = true };
@@ -1065,7 +1065,7 @@ namespace CometServer.Services.Operations
         /// </exception>
         private void ApplyCopyOperations(CdpPostOperation operation, NpgsqlTransaction transaction, string requestPartition)
         {
-            if (!operation.Copy.Any())
+            if (operation.Copy.Count == 0)
             {
                 return;
             }
@@ -1409,7 +1409,7 @@ namespace CometServer.Services.Operations
                     // get persisted thing
                     var updatedThing = GetPersistedItem(transaction, resolvedInfo.Partition, service, resolvedInfo.InstanceInfo.Iid, securityContext);
 
-                    if (orderedListToBeChecked.Any())
+                    if (orderedListToBeChecked.Count != 0)
                     {
                         OrderedItemListValidation(transaction, updatedThing, orderedListToBeChecked, metaInfo);
                     }

--- a/CometServer/Services/Operations/SideEffects/Implementation/ConversionBasedUnitSideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/ConversionBasedUnitSideEffect.cs
@@ -93,9 +93,7 @@ namespace CometServer.Services.Operations.SideEffects
                 if (referenceUnitId == thing.Iid)
                 {
                     throw new AcyclicValidationException(
-                        string.Format(
-                            "ConversionBasedUnit {0} cannot have itself as a RefernceUnit",
-                            thing.Iid));
+                        $"ConversionBasedUnit {thing.Iid} cannot have itself as a RefernceUnit");
                 }
 
                 // Get RDL chain and collect units' ids
@@ -110,9 +108,7 @@ namespace CometServer.Services.Operations.SideEffects
                 if (!unitIdsFromChain.Contains(referenceUnitId))
                 {
                     throw new AcyclicValidationException(
-                        string.Format(
-                            "ConversionBasedUnit {0} cannot have a RefernceUnit from outside the RDL chain",
-                            thing.Iid));
+                        $"ConversionBasedUnit {thing.Iid} cannot have a RefernceUnit from outside the RDL chain");
                 }
 
                 // Get all ConversionBasedUnits
@@ -121,13 +117,10 @@ namespace CometServer.Services.Operations.SideEffects
                     .ToList();
 
                 // Check reference unit that it is acyclic
-                if (!this.IsReferenceUnitAcyclic(units, referenceUnitId, thing.Iid))
+                if (!IsReferenceUnitAcyclic(units, referenceUnitId, thing.Iid))
                 {
                     throw new AcyclicValidationException(
-                        string.Format(
-                            "ConversionBasedUnit {0} cannot have a RefernceUnit {1} that leads to cyclic dependency",
-                            thing.Iid,
-                            referenceUnitId));
+                        $"ConversionBasedUnit {thing.Iid} cannot have a RefernceUnit {referenceUnitId} that leads to cyclic dependency");
                 }
             }
         }
@@ -186,10 +179,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// <returns>
         /// The <see cref="bool"/> whether a reference unit will not lead to cyclic dependency.
         /// </returns>
-        private bool IsReferenceUnitAcyclic(
-            List<ConversionBasedUnit> units,
-            Guid referenceUnitId,
-            Guid conversionBasedUnitId)
+        private static bool IsReferenceUnitAcyclic(List<ConversionBasedUnit> units, Guid referenceUnitId, Guid conversionBasedUnitId)
         {
             Guid? nextContainingGroupId = referenceUnitId;
 

--- a/CometServer/Services/Operations/SideEffects/Implementation/ElementDefinitionSideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/ElementDefinitionSideEffect.cs
@@ -104,7 +104,7 @@ namespace CometServer.Services.Operations.SideEffects
         public override bool BeforeCreate(ElementDefinition thing, Thing container, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
         {
             // inject the organizational participant of the creator to the ED before creating
-            if (this.CredentialsService.Credentials != null && this.CredentialsService.Credentials.EngineeringModelSetup.OrganizationalParticipant.Any() && !this.CredentialsService.Credentials.IsDefaultOrganizationalParticipant)
+            if (this.CredentialsService.Credentials != null && this.CredentialsService.Credentials.EngineeringModelSetup.OrganizationalParticipant.Count != 0 && !this.CredentialsService.Credentials.IsDefaultOrganizationalParticipant)
             {
                 if (!thing.OrganizationalParticipant.Contains(this.CredentialsService.Credentials.OrganizationalParticipant.Iid))
                 {

--- a/CometServer/Services/Operations/SideEffects/Implementation/EngineeringModelSetupSideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/EngineeringModelSetupSideEffect.cs
@@ -150,7 +150,7 @@ namespace CometServer.Services.Operations.SideEffects
                 throw new InvalidOperationException(errorMessage);
             }
 
-            if (!thing.SourceEngineeringModelSetupIid.HasValue && !thing.ActiveDomain.Any())
+            if (!thing.SourceEngineeringModelSetupIid.HasValue && thing.ActiveDomain.Count == 0)
             {
                 // new engineeringmodelsetup without active domain, set the user's default domain as the active domain
                 var defaultDomain = this.CredentialsService.Credentials.Person.DefaultDomain;
@@ -168,7 +168,7 @@ namespace CometServer.Services.Operations.SideEffects
 
             if (thing.SourceEngineeringModelSetupIid.HasValue)
             {
-                if (thing.RequiredRdl.Any())
+                if (thing.RequiredRdl.Count != 0)
                 {
                     throw new InvalidOperationException("The RequiredRdl cannot be specified if the EngineeringModel is created based on an existing EngineeringModel.");
                 }

--- a/CometServer/Services/Operations/SideEffects/Implementation/EngineeringModelSetupSideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/EngineeringModelSetupSideEffect.cs
@@ -219,7 +219,7 @@ namespace CometServer.Services.Operations.SideEffects
             if (thing.SourceEngineeringModelSetupIid.HasValue)
             {
                 this.Logger.LogInformation("Create a Copy of an EngineeringModel");
-                this.CreateCopyEngineeringModel(thing, container, transaction, partition, securityContext);
+                this.CreateCopyEngineeringModel(thing, transaction, securityContext);
 
                 this.Logger.LogInformation("Create revisions for created EngineeringModel");
                 this.RevisionService.SaveRevisions(transaction, this.RequestUtils.GetEngineeringModelPartitionString(thing.EngineeringModelIid), actor, FirstRevision);
@@ -227,7 +227,7 @@ namespace CometServer.Services.Operations.SideEffects
                 return;
             }
 
-            this.CreateDefaultEngineeringModel(thing, container, transaction, partition, securityContext);
+            this.CreateDefaultEngineeringModel(thing, container, transaction, partition);
 
             // Create revisions for created EngineeringModel
             this.RevisionService.SaveRevisions(transaction, this.RequestUtils.GetEngineeringModelPartitionString(thing.EngineeringModelIid), actor, FirstRevision);
@@ -267,7 +267,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// <param name="transaction">The current transaction</param>
         /// <param name="partition">The partition</param>
         /// <param name="securityContext">The security context</param>
-        private void CreateCopyEngineeringModel(EngineeringModelSetup thing, Thing container, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
+        private void CreateCopyEngineeringModel(EngineeringModelSetup thing, NpgsqlTransaction transaction, ISecurityContext securityContext)
         {
             // copy data from the source engineering-model
             this.ModelCreatorManager.CopyEngineeringModelData(thing, transaction, securityContext);
@@ -281,7 +281,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// <param name="transaction">The current transaction</param>
         /// <param name="partition">The partition</param>
         /// <param name="securityContext">The security context</param>
-        private void CreateDefaultEngineeringModel(EngineeringModelSetup thing, Thing container, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
+        private void CreateDefaultEngineeringModel(EngineeringModelSetup thing, Thing container, NpgsqlTransaction transaction, string partition)
         {
             // No need to create a model RDL for the created EngineeringModelSetup since is handled in the client. It happens in the same transaction as the creation of the EngineeringModelSetup itself
             var firstIterationSetup = this.CreateIterationSetup(thing, transaction, partition);

--- a/CometServer/Services/Operations/SideEffects/Implementation/FolderSideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/FolderSideEffect.cs
@@ -213,7 +213,7 @@ namespace CometServer.Services.Operations.SideEffects
                 .Cast<Folder>().ToList();
 
             // Check whether containing folder is acyclic
-            if (!this.IsFolderAcyclic(folders, containingFolderId, thing.Iid))
+            if (!IsFolderAcyclic(folders, containingFolderId, thing.Iid))
             {
                 throw new AcyclicValidationException(
                     $"Folder {thing.Name} {thing.Iid} cannot have a containing Folder {containingFolderId} that leads to cyclic dependency");
@@ -235,7 +235,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// <returns>
         /// The <see cref="bool"/> whether a containing folder will not lead to cyclic dependency.
         /// </returns>
-        private bool IsFolderAcyclic(List<Folder> folders, Guid containingFolderId, Guid folderId)
+        private static bool IsFolderAcyclic(List<Folder> folders, Guid containingFolderId, Guid folderId)
         {
             Guid? nextContainingFolderId = containingFolderId;
 

--- a/CometServer/Services/Operations/SideEffects/Implementation/GlossarySideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/GlossarySideEffect.cs
@@ -74,7 +74,7 @@ namespace CometServer.Services.Operations.SideEffects
                 return;
             }
 
-            if (!glossary.Term.Any())
+            if (glossary.Term.Count == 0)
             {
                 return;
             }

--- a/CometServer/Services/Operations/SideEffects/Implementation/ParameterGroupSideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/ParameterGroupSideEffect.cs
@@ -207,20 +207,14 @@ namespace CometServer.Services.Operations.SideEffects
             if (containingGroupId == thing.Iid)
             {
                 throw new AcyclicValidationException(
-                    string.Format(
-                        "ParameterGroup {0} {1} cannot have itself as a containing ParameterGroup.",
-                        thing.Name,
-                        thing.Iid));
+                    $"ParameterGroup {thing.Name} {thing.Iid} cannot have itself as a containing ParameterGroup.");
             }
 
             // Check that containing group is from the same element definition
             if (!((ElementDefinition)container).ParameterGroup.Contains(containingGroupId))
             {
                 throw new AcyclicValidationException(
-                    string.Format(
-                        "ParameterGroup {0} {1} cannot have a ParameterGroup from outside the current elementDefinition.",
-                        thing.Name,
-                        thing.Iid));
+                    $"ParameterGroup {thing.Name} {thing.Iid} cannot have a ParameterGroup from outside the current elementDefinition.");
             }
 
             // Get all parameter groups from the container
@@ -231,14 +225,10 @@ namespace CometServer.Services.Operations.SideEffects
                 securityContext).Cast<ParameterGroup>().ToList();
 
             // Check whether containing parameter group is acyclic
-            if (!this.IsParameterGroupAcyclic(parameterGroups, containingGroupId, thing.Iid))
+            if (!IsParameterGroupAcyclic(parameterGroups, containingGroupId, thing.Iid))
             {
                 throw new AcyclicValidationException(
-                    string.Format(
-                        "ParameterGroup {0} {1} cannot have a containing ParameterGroup {2} that leads to cyclic dependency",
-                        thing.Name,
-                        thing.Iid,
-                        containingGroupId));
+                    $"ParameterGroup {thing.Name} {thing.Iid} cannot have a containing ParameterGroup {containingGroupId} that leads to cyclic dependency");
             }
         }
 
@@ -257,10 +247,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// <returns>
         /// The <see cref="bool"/> whether a containing parameter group will not lead to cyclic dependency.
         /// </returns>
-        private bool IsParameterGroupAcyclic(
-            List<ParameterGroup> parameterGroups,
-            Guid containingGroupId,
-            Guid parameterGroupId)
+        private static bool IsParameterGroupAcyclic(List<ParameterGroup> parameterGroups, Guid containingGroupId, Guid parameterGroupId)
         {
             Guid? nextContainingGroupId = containingGroupId;
 

--- a/CometServer/Services/Operations/SideEffects/Implementation/ParameterSideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/ParameterSideEffect.cs
@@ -374,7 +374,7 @@ namespace CometServer.Services.Operations.SideEffects
                 securityContext);
 
             // clean up old values
-            this.DeleteOldValueSet(transaction, partition, originalThing, parameterOverrides, parameterSubscriptions);
+            this.DeleteOldValueSet(transaction, partition, originalThing);
         }
 
         /// <summary>
@@ -666,7 +666,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// <param name="parameterSubscriptions">
         /// The <see cref="ParameterSubscription"/> which value-sets to reset
         /// </param>
-        private void DeleteOldValueSet(NpgsqlTransaction transaction, string partition, Parameter originalThing, IReadOnlyList<ParameterOverride> parameterOverrides, IReadOnlyList<ParameterSubscription> parameterSubscriptions)
+        private void DeleteOldValueSet(NpgsqlTransaction transaction, string partition, Parameter originalThing)
         {
             foreach (var valueset in originalThing.ValueSet)
             {

--- a/CometServer/Services/Operations/SideEffects/Implementation/ParameterSideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/ParameterSideEffect.cs
@@ -345,7 +345,7 @@ namespace CometServer.Services.Operations.SideEffects
                 }
 
                 // Remove the subscriptions owned by the new owner of the Parameter on all parameterOverrides
-                foreach (var parameterOverride in parameterOverrides.Where(o => o.ParameterSubscription.Any()))
+                foreach (var parameterOverride in parameterOverrides.Where(o => o.ParameterSubscription.Count != 0))
                 {
                     var subscriptionToRemove = parameterSubscriptions.SingleOrDefault(
                         s => parameterOverride.ParameterSubscription.Contains(s.Iid)

--- a/CometServer/Services/Operations/SideEffects/Implementation/ParameterSubscriptionSideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/ParameterSubscriptionSideEffect.cs
@@ -43,7 +43,6 @@ namespace CometServer.Services.Operations.SideEffects
     using ParameterOrOverrideBase = CDP4Common.DTO.ParameterOrOverrideBase;
     using ParameterSubscription = CDP4Common.DTO.ParameterSubscription;
     using ParameterSubscriptionValueSet = CDP4Common.DTO.ParameterSubscriptionValueSet;
-    using ParameterValueSetBase = CDP4Common.DTO.ParameterValueSetBase;
 
     /// <summary>
     /// The purpose of the <see cref="ParameterSubscriptionSideEffect"/> Side-Effect class is to execute additional logic before and after a specific operation is performed.
@@ -133,7 +132,7 @@ namespace CometServer.Services.Operations.SideEffects
                 throw new InvalidOperationException("The owner cannot be empty.");
             }
 
-            this.CheckOwnership(thing, container);
+            CheckOwnership(thing, container);
 
             return this.IsUniqueSubscription(transaction, partition, securityContext, thing, container);
         }
@@ -263,7 +262,7 @@ namespace CometServer.Services.Operations.SideEffects
             ISecurityContext securityContext, 
             ClasslessDTO rawUpdateInfo)
         {
-            this.CheckOwnership(thing, container);
+            CheckOwnership(thing, container);
         }
         
         /// <summary>
@@ -275,7 +274,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// <param name="container">
         /// The container instance of the <see cref="Thing"/> that is inspected.
         /// </param>
-        private void CheckOwnership(ParameterSubscription thing, Thing container)
+        private static void CheckOwnership(ParameterSubscription thing, Thing container)
         {
             if (thing.Owner == ((CDP4Common.DTO.ParameterOrOverrideBase)container).Owner)
             {

--- a/CometServer/Services/Operations/SideEffects/Implementation/ParticipantSideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/ParticipantSideEffect.cs
@@ -68,7 +68,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// </param>
         public override void BeforeUpdate(Participant thing, Thing container, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext, ClasslessDTO rawUpdateInfo)
         {
-            this.ValidateSelectedDomain(thing, rawUpdateInfo);
+            ValidateSelectedDomain(thing, rawUpdateInfo);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// The raw <see cref="ClasslessDTO"/> instance only contains values for properties that are to be updated.
         /// It is important to note that this variable is not to be edited likely: it can/will change the operation processor outcome.
         /// </param>
-        private void ValidateSelectedDomain(Participant thing, ClasslessDTO rawUpdateInfo)
+        private static void ValidateSelectedDomain(Participant thing, ClasslessDTO rawUpdateInfo)
         {
             if (rawUpdateInfo.ContainsKey(SelectedDomainKey))
             {

--- a/CometServer/Services/Operations/SideEffects/Implementation/PersonSideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/PersonSideEffect.cs
@@ -89,7 +89,7 @@ namespace CometServer.Services.Operations.SideEffects
         {
             string passwordValue;
 
-            if (this.TryExtractPasswordUpdate(rawUpdateInfo, out passwordValue))
+            if (TryExtractPasswordUpdate(rawUpdateInfo, out passwordValue))
             {
                 // A password change is invoked:
                 // encapsulate the new 'clear-text' password with a token to signal the ORM layer that further specific processing is required
@@ -145,7 +145,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// <returns>
         /// The <see cref="bool"/>.
         /// </returns>
-        private bool TryExtractPasswordUpdate(ClasslessDTO rawUpdateInfo, out string passwordValue)
+        private static bool TryExtractPasswordUpdate(ClasslessDTO rawUpdateInfo, out string passwordValue)
         {
             if (!rawUpdateInfo.ContainsKey(PasswordKey))
             {

--- a/CometServer/Services/Operations/SideEffects/Implementation/SiteReferenceDataLibrarySideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/SiteReferenceDataLibrarySideEffect.cs
@@ -157,20 +157,14 @@ namespace CometServer.Services.Operations.SideEffects
             if (requiredRdlId == thing.Iid)
             {
                 throw new AcyclicValidationException(
-                    string.Format(
-                        "SiteReferenceDataLibrary {0} {1} cannot have itself as a required SiteReferenceDataLibrary.",
-                        thing.Name,
-                        thing.Iid));
+                    $"SiteReferenceDataLibrary {thing.Name} {thing.Iid} cannot have itself as a required SiteReferenceDataLibrary.");
             }
 
             // Check that required rdl is from the same siteDirectory
             if (!((SiteDirectory)container).SiteReferenceDataLibrary.Contains(requiredRdlId))
             {
                 throw new AcyclicValidationException(
-                    string.Format(
-                        "SiteReferenceDataLibrary {0} {1} cannot have a SiteReferenceDataLibrary from outside the current SiteDirectory.",
-                        thing.Name,
-                        thing.Iid));
+                    $"SiteReferenceDataLibrary {thing.Name} {thing.Iid} cannot have a SiteReferenceDataLibrary from outside the current SiteDirectory.");
             }
 
             // Get all rdls from the SiteDirectory
@@ -181,14 +175,10 @@ namespace CometServer.Services.Operations.SideEffects
                 securityContext).Cast<SiteReferenceDataLibrary>().ToList();
 
             // Check whether required rdl is acyclic
-            if (!this.IsRdlAcyclic(rdls, requiredRdlId, thing.Iid))
+            if (!IsRdlAcyclic(rdls, requiredRdlId, thing.Iid))
             {
                 throw new AcyclicValidationException(
-                    string.Format(
-                        "SiteReferenceDataLibrary {0} {1} cannot have a requred rdl {2} that leads to cyclic dependency",
-                        thing.Name,
-                        thing.Iid,
-                        requiredRdlId));
+                    $"SiteReferenceDataLibrary {thing.Name} {thing.Iid} cannot have a requred rdl {requiredRdlId} that leads to cyclic dependency");
             }
         }
 
@@ -207,7 +197,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// <returns>
         /// The <see cref="bool"/> whether a required rdl will not lead to cyclic dependency.
         /// </returns>
-        private bool IsRdlAcyclic(List<SiteReferenceDataLibrary> rdls, Guid requiredRdlId, Guid rdlId)
+        private static bool IsRdlAcyclic(List<SiteReferenceDataLibrary> rdls, Guid requiredRdlId, Guid rdlId)
         {
             Guid? nextRequiredRdlId = requiredRdlId;
 

--- a/CometServer/Services/Operations/SideEffects/Implementation/SpecializedQuantityKindSideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/SpecializedQuantityKindSideEffect.cs
@@ -74,8 +74,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// The <see cref="ClasslessDTO"/> instance only contains values for properties that are to be updated.
         /// It is important to note that this variable is not to be changed likely as it can/will change the operation processor outcome.
         /// </param>
-        public override void BeforeUpdate(
-            SpecializedQuantityKind thing,
+        public override void BeforeUpdate(SpecializedQuantityKind thing,
             Thing container,
             NpgsqlTransaction transaction,
             string partition,
@@ -120,7 +119,7 @@ namespace CometServer.Services.Operations.SideEffects
                     .Cast<SpecializedQuantityKind>().ToList();
 
                 // Check whether containing folder is acyclic
-                if (!this.IsSpecializedQuantityKindAcyclic(parameterTypes, kindId, thing.Iid))
+                if (!IsSpecializedQuantityKindAcyclic(parameterTypes, kindId, thing.Iid))
                 {
                     throw new AcyclicValidationException(
                         string.Format(
@@ -150,11 +149,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// <returns>
         /// The list of parameter types ids.
         /// </returns>
-        private List<Guid> GetParameterTypeIdsFromRdlChain(
-            NpgsqlTransaction transaction,
-            string partition,
-            ISecurityContext securityContext,
-            Guid? rdlId)
+        private List<Guid> GetParameterTypeIdsFromRdlChain(NpgsqlTransaction transaction, string partition, ISecurityContext securityContext, Guid? rdlId)
         {
             var availableRdls = this.SiteReferenceDataLibraryService.Get(transaction, partition, null, securityContext)
                 .Cast<SiteReferenceDataLibrary>().ToList();
@@ -186,10 +181,7 @@ namespace CometServer.Services.Operations.SideEffects
         /// <returns>
         /// The <see cref="bool"/> whether a specialized quantity kind will not lead to cyclic dependency.
         /// </returns>
-        private bool IsSpecializedQuantityKindAcyclic(
-            List<SpecializedQuantityKind> parameterTypes,
-            Guid generalKindId,
-            Guid specializedQuantityKindId)
+        private static bool IsSpecializedQuantityKindAcyclic(List<SpecializedQuantityKind> parameterTypes, Guid generalKindId, Guid specializedQuantityKindId)
         {
             Guid? nextGeneralKindId = generalKindId;
 

--- a/CometServer/Services/Revision/RevisionResolver.cs
+++ b/CometServer/Services/Revision/RevisionResolver.cs
@@ -69,7 +69,7 @@ namespace CometServer.Services
 
             var revisions = this.RevisionDao.ReadRevisionRegistry(transaction, partition).ToList();
 
-            if (revisions.Any())
+            if (revisions.Count != 0)
             {
                 resolvedRevisionFrom = revisions.OrderBy(x => x.Revision).First().Revision;
                 resolvedRevisionTo = revisions.OrderBy(x => x.Revision).Last().Revision;

--- a/CometServer/Services/Supplemental/AccessRightKindValidationService.cs
+++ b/CometServer/Services/Supplemental/AccessRightKindValidationService.cs
@@ -127,7 +127,7 @@ namespace CometServer.Services
                 throw new InvalidCastException("The supplied thing is not an instance of ParticipantPermission.");
             }
 
-            if (!this.IsOwnedClassKind(participantPermission.ObjectClass.ToString())
+            if (!IsOwnedClassKind(participantPermission.ObjectClass.ToString())
                 && participantPermission.AccessRight == ParticipantAccessRightKind.MODIFY_IF_OWNER)
             {
                 return false;
@@ -145,10 +145,11 @@ namespace CometServer.Services
         /// <returns>
         /// The <see cref="bool"/> whether the classKind is owned.
         /// </returns>
-        private bool IsOwnedClassKind(string typeName)
+        private static bool IsOwnedClassKind(string typeName)
         {
             // for some reason single multiples type matching the conditions
             var type = typeof(Thing).Assembly.GetTypes().FirstOrDefault(x => !string.IsNullOrWhiteSpace(x.FullName) && x.FullName.Contains($"{typeof(Thing).Namespace}.{typeName}"));
+
             if (type == null)
             {
                 throw new InvalidOperationException($"No type associated to classkind {typeName}");

--- a/CometServer/Services/Supplemental/IterationService.cs
+++ b/CometServer/Services/Supplemental/IterationService.cs
@@ -160,11 +160,6 @@ namespace CometServer.Services
                 iteration = activeIteration;
             }
 
-            if (iteration == null)
-            {
-                throw new ThingNotFoundException($"The active iteration could not be found for partition {partition}.");
-            }
-
             return iteration;
         }
 

--- a/CometServer/Services/Supplemental/ModelReferenceDataLibraryService.cs
+++ b/CometServer/Services/Supplemental/ModelReferenceDataLibraryService.cs
@@ -72,7 +72,7 @@ namespace CometServer.Services
             }
 
             var requiredRdls = new List<ReferenceDataLibrary> { mrdl };
-            this.TryCopyToRequiredRdls(this.GetRequiredRdl(transaction, mrdl), requiredRdls);
+            TryCopyToRequiredRdls(this.GetRequiredRdl(transaction, mrdl), requiredRdls);
 
             return requiredRdls;
         }
@@ -98,8 +98,8 @@ namespace CometServer.Services
 
             if (requiredRdl != null)
             {
-                this.TryCopyToRequiredRdls(new[] { requiredRdl }, requiredRdls);
-                this.TryCopyToRequiredRdls(this.GetRequiredRdl(transaction, requiredRdl), requiredRdls);
+                TryCopyToRequiredRdls(new[] { requiredRdl }, requiredRdls);
+                TryCopyToRequiredRdls(this.GetRequiredRdl(transaction, requiredRdl), requiredRdls);
             }
 
             return requiredRdls;
@@ -110,7 +110,7 @@ namespace CometServer.Services
         /// </summary>
         /// <param name="source">The source <see cref="IEnumerable{ReferenceDataLibrary}"/></param>
         /// <param name="target">The target <see cref="ICollection{ReferenceDataLibrary}"/></param>
-        private void TryCopyToRequiredRdls(IEnumerable<ReferenceDataLibrary> source, ICollection<ReferenceDataLibrary> target)
+        private static void TryCopyToRequiredRdls(IEnumerable<ReferenceDataLibrary> source, ICollection<ReferenceDataLibrary> target)
         {
             foreach (var possibleAdditionalRdl in source)
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

- [Add] JsonExchangeFileWriter => person null check
- [Remove] superfluous "iteration == null" from  IterationService.GetActiveIteration
- [Refactor] string.format and replace with string interpolation
- [SQ] improvements - improve usage of arrays
- [SQ] CA1822 - no instance data access, make static
- [SQ] CA1860 - Prefer comparing 'Count' to 0 rather than using 'Any()', both for clarity and for performance
- [SQ] CA1507 - Use nameof in place of string literal
- [SQ] CS0169 - remove unused fields
- [SQ] remove unused method parameters
- [SQ] CA2253 - Named placeholders in the logging message template should not be comprised of only numeric characters

<!-- Thanks for contributing to COMET Web Services! -->