### PR TITLE
Allow CORS to expose custom Header (required for WASM)

### DIFF
--- a/CometServer/Startup.cs
+++ b/CometServer/Startup.cs
@@ -127,6 +127,7 @@ namespace CometServer
                         builder.AllowAnyOrigin();
                         builder.AllowAnyHeader();
                         builder.AllowAnyMethod();
+                        builder.WithExposedHeaders("*");
                     });
             });
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
CORS now exposes Http Header. Not exposing it provides exception on the DAL layer with Blazor WebAssembly because custom CDP Headers where hidden.
<!-- Thanks for contributing to COMET Web Services! -->