### PR TITLE
[Improve] File handling in support of Domain and Common filestore

### DIFF
--- a/CometServer/Configuration/MidtierConfig.cs
+++ b/CometServer/Configuration/MidtierConfig.cs
@@ -39,6 +39,7 @@ namespace CometServer.Configuration
             // set defaults
             this.UploadDirectory = "upload";
             this.FileStorageDirectory = "storage";
+            this.TemporaryFileStorageDirectory = "tempstorage";
             this.IsExportEnabled = true;
             this.ExportDirectory = "export";
             this.BacktierWaitTime = 300;
@@ -54,6 +55,7 @@ namespace CometServer.Configuration
         {
             this.UploadDirectory = configuration["Midtier:UploadDirectory"];
             this.FileStorageDirectory = configuration["Midtier:FileStorageDirectory"];
+            this.TemporaryFileStorageDirectory = configuration["Midtier:TemporaryFileStorageDirectory"];
             this.IsExportEnabled = bool.Parse(configuration["Midtier:IsExportEnabled"]);
             this.ExportDirectory = configuration["Midtier:ExportDirectory"];
             this.BacktierWaitTime = int.Parse(configuration["Midtier:BacktierWaitTime"]);
@@ -74,6 +76,14 @@ namespace CometServer.Configuration
         /// The default value is storage
         /// </remarks>
         public string FileStorageDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the temporary file directory that the mid tier uses
+        /// </summary>
+        /// <remarks>
+        /// The default value is tempstorage
+        /// </remarks>
+        public string TemporaryFileStorageDirectory { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the export route is enabled or not

--- a/CometServer/Modules/10-25/ApiBase.cs
+++ b/CometServer/Modules/10-25/ApiBase.cs
@@ -830,7 +830,7 @@ namespace CometServer.Modules
 
                 // use the file hash value to easily identify the multipart content for each respective filerevision hash entry
 
-                var fileInfo = new FileInfo($"{folderPath}.zio");
+                var fileInfo = new FileInfo($"{folderPath}.zip");
                 
                 binaryContent.Headers.Add(HttpConstants.ContentDispositionHeader, $"attachment; filename={fileInfo.Name}");
 

--- a/CometServer/Modules/10-25/ApiBase.cs
+++ b/CometServer/Modules/10-25/ApiBase.cs
@@ -829,7 +829,10 @@ namespace CometServer.Modules
                 binaryContent.Headers.Add(HttpConstants.ContentTypeHeader, HttpConstants.MimeTypeOctetStream);
 
                 // use the file hash value to easily identify the multipart content for each respective filerevision hash entry
-                binaryContent.Headers.Add(HttpConstants.ContentDispositionHeader, $"attachment; filename={folderPath + ".zip"}");
+
+                var fileInfo = new FileInfo($"{folderPath}.zio");
+                
+                binaryContent.Headers.Add(HttpConstants.ContentDispositionHeader, $"attachment; filename={fileInfo.Name}");
 
                 binaryContent.Headers.Add(HttpConstants.ContentLengthHeader, fileSize.ToString());
                 content.Add(binaryContent);

--- a/CometServer/Program.cs
+++ b/CometServer/Program.cs
@@ -100,6 +100,7 @@ namespace CometServer
 
                 logger.LogInformation($"Midtier-UploadDirectory: {appConfigService.AppConfig.Midtier.UploadDirectory}");
                 logger.LogInformation($"Midtier-FileStorageDirectory: {appConfigService.AppConfig.Midtier.FileStorageDirectory}");
+                logger.LogInformation($"Midtier-TemporaryFileStorageDirectory: {appConfigService.AppConfig.Midtier.TemporaryFileStorageDirectory}");
                 logger.LogInformation($"Midtier-IsExportEnabled: {appConfigService.AppConfig.Midtier.IsExportEnabled}");
                 logger.LogInformation($"Midtier-ExportDirectory: {appConfigService.AppConfig.Midtier.ExportDirectory}");
                 logger.LogInformation($"Midtier-BacktierWaitTime: {appConfigService.AppConfig.Midtier.BacktierWaitTime}");

--- a/CometServer/appsettings.Development.json
+++ b/CometServer/appsettings.Development.json
@@ -9,6 +9,7 @@
   "Midtier": {
     "UploadDirectory": "upload",
     "FileStorageDirectory": "storage",
+    "TemporaryFileStorageDirectory": "tempstorage",
     "IsExportEnabled": true,
     "ExportDirectory": "export",
     "BacktierWaitTime": 300

--- a/CometServer/appsettings.Production.json
+++ b/CometServer/appsettings.Production.json
@@ -9,6 +9,7 @@
   "Midtier": {
     "UploadDirectory": "upload",
     "FileStorageDirectory": "storage",
+    "TemporaryFileStorageDirectory": "tempstorage",
     "IsExportEnabled": true,
     "ExportDirectory": "export",
     "BacktierWaitTime": 300

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
 WORKDIR /app
 RUN mkdir /app/logs
 RUN mkdir /app/storage
+RUN mkdir /app/tempstorage
 RUN mkdir /app/upload
 
 RUN mkdir /app/Authentication/


### PR DESCRIPTION
[Refactor] FileBinaryService to make use of SHA1.Create instead of SHA1Managed

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

- [Improve] File handling in support of Domain and Common filestore
- [Add] TemporaryFileStorageDirectory setting
- [Refactor] FileBinaryService to make use of SHA1.Create instead of SHA1Managed

<!-- Thanks for contributing to COMET Web Services! -->