### PR TITLE
[Improve] Cdp4TransactionManager -> add private rawSessionInstant field to limit the amount of times the dbase is hit

### DIFF
--- a/CometServer/Helpers/ICdp4TransactionManager.cs
+++ b/CometServer/Helpers/ICdp4TransactionManager.cs
@@ -28,14 +28,14 @@ namespace CometServer.Helpers
 
     using CDP4Common.DTO;
     
-    using CDP4Orm.Dao;
-
     using CometServer.Authorization;
 
     using Npgsql;
 
     /// <summary>
-    /// A wrapper interface for the <see cref="NpgsqlTransaction"/> class, allowing temporal database interaction.
+    /// The purpose of the <see cref="ICdp4TransactionManager"/> is provide a <see cref="NpgsqlTransaction"/> for
+    /// read and write operations to the database while configuring the database to properly process
+    /// any temporal database interactions
     /// </summary>
     public interface ICdp4TransactionManager
     {
@@ -68,7 +68,8 @@ namespace CometServer.Helpers
         /// The user credential information for this request
         /// </param>
         /// <param name="iterationIid">
-        /// An optional iteration id that can be supplied to set the transaction context to the iteration
+        /// the unique identifier of the <see cref="Iteration"/> which is used to retrieve and set the
+        /// corresponding <see cref="IterationSetup"/>
         /// </param>
         /// <returns>
         /// The <see cref="NpgsqlTransaction"/>.
@@ -76,46 +77,44 @@ namespace CometServer.Helpers
         NpgsqlTransaction SetupTransaction(ref NpgsqlConnection connection, Credentials credentials, Guid iterationIid);
 
         /// <summary>
-        /// Get the current transaction time.
+        /// Get the timestamp in the form of a <see cref="DateTime"/> that the <see cref="NpgsqlTransaction"/> was
+        /// created using the <see cref="SetupTransaction"/> method.
         /// </summary>
         /// <param name="transaction">
-        /// The transaction.
+        /// The active <see cref="NpgsqlTransaction"/>
         /// </param>
         /// <returns>
         /// The <see cref="DateTime"/>.
         /// </returns>
         DateTime GetTransactionTime(NpgsqlTransaction transaction);
-        
-        /// <summary>
-        /// Get the session timeframe start time.
-        /// </summary>
-        /// <param name="transaction">
-        /// The transaction.
-        /// </param>
-        /// <returns>
-        /// The <see cref="DateTime"/>.
-        /// </returns>
-        DateTime GetSessionTimeFrameStart(NpgsqlTransaction transaction);
 
         /// <summary>
-        /// Get the current session time instant.
+        /// Get the current session time instant value from the database. In case the most current data is to be
+        /// retrieved this value returns (+infinity) which translates to <see cref="DateTime.MaxValue"/>. In case
+        /// a request is made related to time-travel the <see cref="DateTime"/> corresponding to the period_end
+        /// is returned
         /// </summary>
         /// <param name="transaction">
-        /// The transaction.
+        /// The current transaction to the database.
         /// </param>
         /// <returns>
-        /// The <see cref="DateTime"/>.
+        /// A <see cref="DateTime"/> that represents the session Instant (either <see cref="DateTime.MaxValue"/> or
+        /// the <see cref="DateTime"/> corresponding to the period_end
         /// </returns>
         DateTime GetSessionInstant(NpgsqlTransaction transaction);
 
         /// <summary>
-        /// Get the raw current session time instant value from the database.
+        /// Get the raw current session time instant value from the database. In case the most current data is to be
+        /// retrieved this value returns (+infinity) which translates to <see cref="DateTime.MaxValue"/>. In case
+        /// a request is made related to time-travel the <see cref="DateTime"/> corresponding to the period_end
+        /// is returned
         /// </summary>
         /// <param name="transaction">
-        /// The transaction.
+        /// The current transaction to the database.
         /// </param>
         /// <returns>
-        /// The current session instant as an <see cref="object"/>.
+        /// A <see cref="object"/> that represents the session Instant (either <see cref="DateTime.MaxValue"/> or
+        /// the <see cref="DateTime"/> corresponding to the period_end
         /// </returns>
         object GetRawSessionInstant(NpgsqlTransaction transaction);
 
@@ -150,10 +149,10 @@ namespace CometServer.Helpers
         void SetAuditLoggingState(NpgsqlTransaction transaction, bool enabled);
 
         /// <summary>
-        /// The set default context.
+        /// Sets the default temporal context (-infinity, +infinity)
         /// </summary>
         /// <param name="transaction">
-        /// The transaction.
+        /// The active <see cref="NpgsqlTransaction"/>
         /// </param>
         void SetDefaultContext(NpgsqlTransaction transaction);
 

--- a/CometServer/Services/Operations/SideEffects/Implementation/PublicationSideEffect.cs
+++ b/CometServer/Services/Operations/SideEffects/Implementation/PublicationSideEffect.cs
@@ -87,6 +87,7 @@ namespace CometServer.Services.Operations.SideEffects
             // gets all parameter/override which value-set to update
             var parameterToUpdate = this.ParameterService.GetShallow(transaction, partition, thing.PublishedParameter, securityContext).OfType<Parameter>().ToArray();
             var overridesToUpdate = this.ParameterOverrideService.GetShallow(transaction, partition, thing.PublishedParameter, securityContext).OfType<ParameterOverride>().ToArray();
+           
             if (parameterToUpdate.Length + overridesToUpdate.Length != thing.PublishedParameter.Count)
             {
                 throw new InvalidOperationException("All the parameter/override could not be retrieved for update on a publication.");

--- a/CometServer/Services/Supplemental/IPermissionInstanceFilterService.cs
+++ b/CometServer/Services/Supplemental/IPermissionInstanceFilterService.cs
@@ -30,7 +30,8 @@ namespace CometServer.Services
     using CDP4Common.DTO;
 
     /// <summary>
-    /// The permission instance filter service.
+    /// The purpose of the <see cref="IPermissionInstanceFilterService"/> is to filter out any <see cref="PersonPermission"/>
+    /// and <see cref="ParticipantPermission"/> that is not supported by the requested data-model version
     /// </summary>
     public interface IPermissionInstanceFilterService
     {

--- a/CometServer/Services/Supplemental/PermissionInstanceFilterService.cs
+++ b/CometServer/Services/Supplemental/PermissionInstanceFilterService.cs
@@ -45,7 +45,8 @@ namespace CometServer.Services.Supplemental
     using Thing = CDP4Common.DTO.Thing;
 
     /// <summary>
-    /// The permission instance filter service.
+    /// The purpose of the <see cref="PermissionInstanceFilterService"/> is to filter out any <see cref="PersonPermission"/>
+    /// and <see cref="ParticipantPermission"/> that is not supported by the requested data-model version
     /// </summary>
     public class PermissionInstanceFilterService : IPermissionInstanceFilterService
     {
@@ -105,6 +106,7 @@ namespace CometServer.Services.Supplemental
 
             IReadOnlyList<Guid> excludedPersonPermission = new List<Guid>();
             IReadOnlyList<Guid> excludedParticipantPermission = new List<Guid>();
+
             if (personRoles.Length != 0 || personPermissions.Length != 0)
             {
                 excludedPersonPermission = this.GetIgnoredPersonPermissionIds(requestDataModelVersion, personPermissions, personRoles);
@@ -166,6 +168,7 @@ namespace CometServer.Services.Supplemental
                 foreach (var personPermission in personPermissions)
                 {
                     var metainfo = this.MetadataProvider.GetMetaInfo(personPermission.ObjectClass.ToString());
+
                     if (string.IsNullOrEmpty(metainfo.ClassVersion) || requestDataModelVersion >= new Version(metainfo.ClassVersion))
                     {
                         continue;
@@ -215,6 +218,7 @@ namespace CometServer.Services.Supplemental
                 transaction = this.TransactionManager.SetupTransaction(ref connection, null);
 
                 var queryPersonPermissions = inParticipantRoles.SelectMany(x => x.ParticipantPermission).Except(inParticipantPermissions.Select(x => x.Iid)).ToArray();
+
                 var participantPermissions = queryPersonPermissions.Length > 0
                     ? this.ParticipantPermissionDao.Read(transaction, SiteDirectoryData, null, true).Union(inParticipantPermissions)
                     : inParticipantPermissions;
@@ -222,6 +226,7 @@ namespace CometServer.Services.Supplemental
                 foreach (var participantPermission in participantPermissions)
                 {
                     var metainfo = this.MetadataProvider.GetMetaInfo(participantPermission.ObjectClass.ToString());
+
                     if (string.IsNullOrEmpty(metainfo.ClassVersion) || requestDataModelVersion >= new Version(metainfo.ClassVersion))
                     {
                         continue;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

- [Refactor] Cdp4TransactionManager:add private rawSessionInstant field to limit the amount of times the dbase is hit
- Improve] documentation to make methods more explicit

<!-- Thanks for contributing to COMET Web Services! -->