### PR TITLE
Cache and Revision supports BulkWrite

### DIFF
--- a/CDP4Orm/Dao/Cache/ICacheDao.cs
+++ b/CDP4Orm/Dao/Cache/ICacheDao.cs
@@ -24,6 +24,8 @@
 
 namespace CDP4Orm.Dao.Revision
 {
+    using System.Collections.Generic;
+
     using CDP4Common.DTO;
 
     using Npgsql;
@@ -40,5 +42,13 @@ namespace CDP4Orm.Dao.Revision
         /// <param name="partition">The database partition (schema) where the requested resource is stored.</param>
         /// <param name="thing">The revised <see cref="Thing"/></param>
         void Write(NpgsqlTransaction transaction, string partition, Thing thing);
+
+        /// <summary>
+        /// Save a collection of <see cref="Thing"/> to cache tables
+        /// </summary>
+        /// <param name="transaction">The current transaction</param>
+        /// <param name="partition">The database partition (schema) where the requested resource is stored.</param>
+        /// <param name="things">The collection of revised <see cref="Thing"/>s</param>
+        void BulkWrite(NpgsqlTransaction transaction, string partition, IReadOnlyCollection<Thing> things);
     }
 }

--- a/CDP4Orm/Dao/Revision/IRevisionDao.cs
+++ b/CDP4Orm/Dao/Revision/IRevisionDao.cs
@@ -25,6 +25,7 @@
 namespace CDP4Orm.Dao.Revision
 {
     using System;
+    using System.Collections.Generic;
     using System.Collections.ObjectModel;
 
     using CDP4Common.DTO;
@@ -127,5 +128,14 @@ namespace CDP4Orm.Dao.Revision
         /// <param name="fromRevision">The starting revision number for the iteration. If null the current revision is used.</param>
         /// <param name="toRevision">The ending revision number for the iteration. If null it means the iteration is the current one.</param>
         void InsertIterationRevisionLog(NpgsqlTransaction transaction, string partition, Guid iteration, int? fromRevision, int? toRevision);
+
+        /// <summary>
+        /// Save revisions for a collection of <see cref="Thing"/>s
+        /// </summary>
+        /// <param name="transaction">The current transaction</param>
+        /// <param name="partition">The database partition (schema) where the requested resource is stored.</param>
+        /// <param name="things">The revised <see cref="Thing"/></param>
+        /// <param name="actor">The identifier of the person who made this revision</param>
+        void BulkWriteRevision(NpgsqlTransaction transaction, string partition, IReadOnlyCollection<Thing> things, Guid actor);
     }
 }

--- a/CometServer/Services/Cache/CacheService.cs
+++ b/CometServer/Services/Cache/CacheService.cs
@@ -24,6 +24,8 @@
 
 namespace CometServer.Services
 {
+    using System.Collections.Generic;
+
     using CDP4Common.DTO;
 
     using CDP4Orm.Dao.Revision;
@@ -49,6 +51,17 @@ namespace CometServer.Services
         public void WriteToCache(NpgsqlTransaction transaction, string partition, Thing thing)
         {
             this.CacheDao.Write(transaction, partition, thing);
+        }
+
+        /// <summary>
+        /// Save a collection of <see cref="Thing"/>s to cache tables
+        /// </summary>
+        /// <param name="transaction">The current transaction</param>
+        /// <param name="partition">The database partition (schema) where the requested resource is stored.</param>
+        /// <param name="things">The collection of revised <see cref="Thing"/>s</param>
+        public void BulkWriteToCache(NpgsqlTransaction transaction, string partition, IReadOnlyCollection<Thing> things)
+        {
+            this.CacheDao.BulkWrite(transaction, partition, things);
         }
     }
 }

--- a/CometServer/Services/Cache/ICacheService.cs
+++ b/CometServer/Services/Cache/ICacheService.cs
@@ -24,6 +24,8 @@
 
 namespace CometServer.Services
 {
+    using System.Collections.Generic;
+
     using CDP4Common.DTO;
 
     using Npgsql;
@@ -40,5 +42,13 @@ namespace CometServer.Services
         /// <param name="partition">The database partition (schema) where the requested resource is stored.</param>
         /// <param name="thing">The revised <see cref="Thing"/></param>
         void WriteToCache(NpgsqlTransaction transaction, string partition, Thing thing);
+
+        /// <summary>
+        /// Save a collection of <see cref="Thing"/>s to cache tables
+        /// </summary>
+        /// <param name="transaction">The current transaction</param>
+        /// <param name="partition">The database partition (schema) where the requested resource is stored.</param>
+        /// <param name="things">The collection of revised <see cref="Thing"/>s</param>
+        void BulkWriteToCache(NpgsqlTransaction transaction, string partition, IReadOnlyCollection<Thing> things);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Writing to Cache and Revision table now support BulkWrite. This BulkWrite create one INSERT Query per type which lower the number of Queries to run 
<!-- Thanks for contributing to COMET Web Services! -->