### PR TITLE
[FIX] No second partition lookup for SiteDirectory items in ResolvePartition; fixes #325

### DIFF
--- a/CometServer/Services/Resolve/ResolveService.cs
+++ b/CometServer/Services/Resolve/ResolveService.cs
@@ -349,6 +349,7 @@ namespace CometServer.Services
                     if (staticTypeInfo == "SiteDirectory")
                     {
                         result.Add(staticTypeInfo);
+                        continue;
                     }
 
                     if (staticTypeInfo != null)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
[FIX] No second partition lookup for SiteDirectory items in ResolvePartition; fixes #325