### PR TITLE
[Update] ServiceMessagingConfig

### DIFF
--- a/CometServer/Configuration/ServiceMessagingConfig.cs
+++ b/CometServer/Configuration/ServiceMessagingConfig.cs
@@ -36,6 +36,14 @@ namespace CometServer.Configuration
         /// </summary>
         public ServiceMessagingConfig()
         {
+            this.IsEnabled =  false;
+            this.Port =  5672;
+            this.AdminPort =  15672;
+            this.MaxConnectionRetryAttempts = 5;
+            this.TimeSpanBetweenAttempts = 1;
+            this.UserName = string.Empty;
+            this.Password = string.Empty;
+            this.HostName = string.Empty;
         }
 
         /// <summary>
@@ -82,12 +90,12 @@ namespace CometServer.Configuration
         public int TimeSpanBetweenAttempts { get; private set; }
 
         /// <summary>
-        /// Gets or sets the user name.
+        /// Gets or sets the user name to connect to the message broker
         /// </summary>
         public string UserName { get; private set; }
 
         /// <summary>
-        /// Gets or sets the user password of the back tier.
+        /// Gets or sets the user password to connect to the message broker
         /// </summary>
         public string Password { get; private set; }
         


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
update the `ServiceMessagingConfig` class to have a constructor used to set default values and update docs

<!-- Thanks for contributing to COMET Web Services! -->